### PR TITLE
Modernized nimble file to NimScript format (fixes warning), fixed nim…

### DIFF
--- a/cligen.nimble
+++ b/cligen.nimble
@@ -1,9 +1,8 @@
-[Package]
-name        = "cligen"
+# Package
 version     = "0.9.3"
 author      = "Charles Blake"
 description = "Infer & generate command-line interace/option/argument parser"
 license     = "MIT/ISC"
 
-[Deps]
-Requires: "nim >= 0.13.1"
+# Deps
+requires    "nim >= 0.13.0"


### PR DESCRIPTION
… compiler dep version (0.13.0) in devel branch, also caused installation issues on Windows