### PR TITLE
Stop trapping exceptions -- until this is explained better

### DIFF
--- a/cligen.nim
+++ b/cligen.nim
@@ -312,7 +312,7 @@ macro dispatchGen*(pro: typed, cmdName: string="", doc: string="",
         `callPrs`
         `callWrapd`
       except:
-        discard
+        raise
   when defined(printDispatch): echo repr(result)  # maybe print generated code
 
 macro dispatch*(pro: typed, cmdName: string="", doc: string="",


### PR DESCRIPTION
Unfortunately, `dispatch(main)` is trapping exceptions from main. That is a big problem. Why not let exceptions propagate? Is there something in particular that needs to be trapped?