### PR TITLE
make positional warning an error since theres an easy way to specify which arg shd be positional

### DIFF
--- a/cligen.nim
+++ b/cligen.nim
@@ -131,8 +131,7 @@ proc posIxGet(positional: NimNode, fpars: NimNode): int =
     if idef[1].kind != nnkEmpty and idef[2].kind == nnkEmpty and
        typeKind(getType(idef[1])) == ntySequence:
       if result != -1:            # Allow multiple seq[T]s via "--" separators?
-        warning("cligen only supports one seq param for positional args; using"&
-                " `" & $fpars[result][0] & "`, not `" & $fpars[i][0] & "`.")
+        error("cligen only supports one seq param for positional args; use `positional` to dispatch to specify which one")
       else:
         result = i
 


### PR DESCRIPTION
/cc @c-blake not sure how I should modify the corresponding code in `test/ref` 

```
==> test/TwoNondefaultedSeq.out <==
TwoNondefaultedSeq.nim(9, 11) template/generic instantiation of `dispatch` from here
cligen.nim(134, 16) Warning: cligen only supports one seq param for positional args; using `args`, not `stuff`. [User]
Usage:
  demo [required&optional-params] [args: string...]
demo entry point with varied, meaningless parameters.
  Options(opt-arg sep :|=|spc):
  -h, --help                            write this help to stdout
  -a=, --alpha=  int          1         set alpha
  -v, --verb     bool         false     set verb
  -s=, --stuff=  ,SV[string]  REQUIRED  set stuff
```
