### PR TITLE
 req arg type shown as [string...] instead of [string] ; nit: print instead of write to stdout

### DIFF
--- a/cligen.nim
+++ b/cligen.nim
@@ -362,8 +362,8 @@ macro dispatchGen*(pro: typed{nkSym}, cmdName: string = "", doc: string = "",
       var `mandId`: seq[string] = @[ ]
       var `mandInFId` = true
       var `tabId`: TextTab =
-        @[ @[ "-" & shortH & ", --help", "", "", "write this help to stdout" ],
-           @[ "--help-syntax", "", "", "print cligen-specific syntax" ] ]
+        @[ @[ "-" & shortH & ", --help", "", "", "print this help" ],
+           @[ "--help-syntax", "", "", "print advanced (cligen-specific) syntax" ] ]
       `apId`.shortNoVal = { shortH[0] }               # argHelp(bool) updates
       `apId`.longNoVal = @[ "help", "help-syntax" ]   # argHelp(bool) appends
       let `setByParseId`: ptr seq[ClParse] = `setByParseP`)
@@ -371,7 +371,7 @@ macro dispatchGen*(pro: typed{nkSym}, cmdName: string = "", doc: string = "",
       result.add(quote do:
        var versionDflt = false
        `apId`.parNm = `vsnOpt`; `apId`.parSh = `vsnSh`; `apId`.parReq = 0
-       `tabId`.add(argHelp(versionDflt, `apId`) & "write version to stdout"))
+       `tabId`.add(argHelp(versionDflt, `apId`) & "print version"))
     let argStart = if mandatory.len > 0: "[required&optional-params]" else:
                                          "[optional-params]"
     let posHelp = if posIx != -1:

--- a/cligen/argcvt.nim
+++ b/cligen/argcvt.nim
@@ -198,7 +198,7 @@ proc argAggSplit*[T](a: var ArgcvtParams, split=true): seq[T] =
   a.sep = old                     #probably don't need to restore, but eh.
 
 proc argAggHelp*(dfls: seq[string]; brkt, dlm: string; typ, dfl: var string) =
-  typ = brkt[0] & typ & brkt[1]
+  typ = brkt[0] & typ & "..." & brkt[1]
   dfl = if dfls.len > 0: dlm & dfls.join(dlm) else: "EMPTY"
 
 # seqs


### PR DESCRIPTION
* req arg type shown as [string...] instead of [string] 
that's just more readable and more consistent both with lots of other cli tools as well as with the way cligen treats non-keyword`seq` (`main [optional-params] [a: string...]`)

* nit: print instead of write to stdout
=> consistent with msg in `--help-syntax` which uses print; less verbose

* added wording: `advanced`