### PR TITLE
unambiguous default value printing

### DIFF
--- a/cligen.nim
+++ b/cligen.nim
@@ -364,7 +364,7 @@ macro dispatchGen*(pro: typed{nkSym}, cmdName: string = "", doc: string = "",
       `apId`.delimit = `delim`
       let shortH = $(`shortHlp`)
       var `allId`: seq[string] = @[ "help", "help-syntax" ]
-      var `mandId`: seq[string] = @[ ]
+      var `mandId`: seq[string]
       var `mandInFId` = true
       var `tabId`: TextTab =
         @[ @[ "-" & shortH & ", --help", "", "", "print this help" ],

--- a/cligen.nim
+++ b/cligen.nim
@@ -397,11 +397,16 @@ macro dispatchGen*(pro: typed{nkSym}, cmdName: string = "", doc: string = "",
         let parNm = $idef[0]
         let sh = toString(shOpt.getOrDefault(parNm))      #Add to perPar helpTab
         let defVal = sdef[0]
-        let hlp=if parNm in helps: helps.getOrDefault(parNm) else: "set "&parNm
+        let hlp =
+          if parNm in helps:
+            helps.getOrDefault(parNm)
+          else:
+            ""
         let isReq = if i in mandatory: true else: false
         result.add(quote do:
          `apId`.parNm = `parNm`; `apId`.parSh = `sh`; `apId`.parReq = `isReq`
-         `tabId`.add(argHelp(`defVal`, `apId`) & `hlp`); `allId`.add(`parNm`) )
+         let descr = getDescription(`defVal`, `parNm`, `hlp`)
+         `tabId`.add(argHelp(`defVal`, `apId`) & descr); `allId`.add(`parNm`) )
         if isReq:
           result.add(quote do: `mandId`.add(`parNm`))
     result.add(quote do:                  # build one large help string
@@ -550,7 +555,7 @@ macro dispatchGen*(pro: typed{nkSym}, cmdName: string = "", doc: string = "",
   let retType=fpars[0]
   result = quote do:
     from os               import commandLineParams
-    from cligen/argcvt    import ArgcvtParams, argParse, argHelp
+    from cligen/argcvt    import ArgcvtParams, argParse, argHelp, getDescription
     from cligen/textUt    import addPrefix, TextTab, alignTable, suggestions
     from cligen/parseopt3 import initOptParser, next, cmdEnd, cmdLongOption,
                                  cmdShortOption, optionNormalize

--- a/cligen/argcvt.nim
+++ b/cligen/argcvt.nim
@@ -235,7 +235,7 @@ proc argParse*[T](dst: var seq[T], dfl: seq[T], a: var ArgcvtParams): bool =
 
 proc argHelp*[T](dfl: seq[T], a: var ArgcvtParams): seq[string]=
   var typ = $T; var df: string
-  var dflSeq: seq[string] = @[ ]
+  var dflSeq: seq[string]
   for d in dfl: dflSeq.add($d)
   argAggHelp(dflSeq, "[]", a.delimit, typ, df)
   result = @[ a.argKeys, typ, a.argDf(df) ]
@@ -287,7 +287,7 @@ proc argParse*[T](dst: var set[T], dfl: set[T], a: var ArgcvtParams): bool =
 
 proc argHelp*[T](dfl: set[T], a: var ArgcvtParams): seq[string]=
   var typ = $T; var df: string
-  var dflSeq: seq[string] = @[ ]
+  var dflSeq: seq[string]
   for d in dfl: dflSeq.add($d)
   argAggHelp(dflSeq, "{}", a.delimit, typ, df)
   result = @[ a.argKeys, typ, a.argDf(df) ]
@@ -319,7 +319,7 @@ proc argParse*[T](dst: var HashSet[T], dfl: HashSet[T],
 
 proc argHelp*[T](dfl: HashSet[T], a: var ArgcvtParams): seq[string]=
   var typ = $T; var df: string
-  var dflSeq: seq[string] = @[ ]
+  var dflSeq: seq[string]
   for d in dfl: dflSeq.add($d)
   argAggHelp(dflSeq, "{}", a.delimit, typ, df)
   result = @[ a.argKeys, typ, a.argDf(df) ]

--- a/cligen/argcvt.nim
+++ b/cligen/argcvt.nim
@@ -207,9 +207,34 @@ proc getDescription*[T](defVal: T, parNm: string, defaultHelp: string): string=
 
   result.add " " & parNm
 
+proc formatHuman(a: string): string =
+  if a.len == 0:
+    result.addQuoted ""
+    return result
+  var isSimple = true
+  for ai in a:
+    # avoid ~ which, if given via `--foo ~bar`, is expanded by shell
+    # avoid , (would cause confusion bc of separator syntax)
+    if ai notin {'a'..'z'} + {'A'..'Z'} + {'0'..'9'} + {'-', '_', '.', '@', ':', '=', '+', '^', '/'}:
+      isSimple = false
+      break
+  if isSimple:
+    result = a
+  else:
+    result.addQuoted a
+
+proc formatHuman(a: seq[string]): string =
+  if a.len == 0: result = "EMPTY"
+  for i in 0..<a.len:
+    if i>0:
+      result.add ","
+    result.add formatHuman(a[i])
+
 proc argAggHelp*(dfls: seq[string]; brkt, dlm: string; typ, dfl: var string) =
   typ = brkt[0] & typ & brkt[1]
-  dfl = ($dfls)[1 .. ^1]
+  # Note: this would print in Nim format: dfl = ($dfls)[1 .. ^1]
+  # TODO: ok to ignore dlm?
+  dfl = formatHuman dfls
 
 # seqs
 proc argParse*[T](dst: var seq[T], dfl: seq[T], a: var ArgcvtParams): bool =

--- a/cligen/argcvt.nim
+++ b/cligen/argcvt.nim
@@ -198,9 +198,18 @@ proc argAggSplit*[T](a: var ArgcvtParams, split=true): seq[T] =
     result.add(parsed)
   a.sep = old                     #probably don't need to restore, but eh.
 
+proc getDescription*[T](defVal: T, parNm: string, defaultHelp: string): string=
+  if defaultHelp.len > 0: return defaultHelp # TODO: what user explicitly set it to empty?
+  when T is seq:
+    result = "append to"
+  else:
+    result = "set"
+
+  result.add " " & parNm
+
 proc argAggHelp*(dfls: seq[string]; brkt, dlm: string; typ, dfl: var string) =
   typ = brkt[0] & typ & brkt[1]
-  dfl = if dfls.len > 0: dlm & dfls.join(dlm) else: "EMPTY"
+  dfl = ($dfls)[1 .. ^1]
 
 # seqs
 proc argParse*[T](dst: var seq[T], dfl: seq[T], a: var ArgcvtParams): bool =


### PR DESCRIPTION
* fixes issue mentioned in this comment: https://github.com/c-blake/cligen/issues/54#issuecomment-443390541
```
the default value formatting for seq params is not good:

* newlines are not escaped, unlike for non-seq string params (see D20181130T172327)
* @[""] prints as nothing_at_all (for DPSV, )
* @[] prints as EMPTY (for DPSV, EMPTY, which is not super consistent)
* it's ambiguous, eg when delimiter = " " (a space), default value for @["", ""] is indistinguishable from default value for @[""] (admittedly, this is rare scenario but still)
```

nim c -r -d:case11 $vitanim_D/testcases/tests/t0000.nim -h

```
Usage:
  main [required&optional-params]
  Options(opt-arg sep :|=|spc):
  -h, --help                                 print this help
  --help-syntax                              print cligen-specific syntax
  -f=, --foo1=   int       REQUIRED          set foo1
  --foo2=        float     REQUIRED          set foo2
  --foo3=        [string]  ["baz1", "baz2"]  append to foo3
  --foo4=        [string]  []                append to foo4
  --foo5=        [string]  [""]              append to foo5
  --foo5b=       [string]  ["", ""]          append to foo5b
  --foo6=        [int]     []                append to foo6
  --foo7=        [int]     ["10"]            append to foo7
  --foo8=        string    ""                set foo8

```


I think this strikes a good balance:
* seq default value is shown un-ambiguously
* it's consistent with how `string` default value is printed (eg wrt escapes, empty, newlines etc)
* I made it clear a seq `--foo3=` "appends to" whereas `--foo6` sets
