### PR TITLE
Fix detection of stable

### DIFF
--- a/cligen/argcvt.nim
+++ b/cligen/argcvt.nim
@@ -5,7 +5,7 @@
 import strformat, sets, ./textUt, parseopt3, critbits, strutils
 from parseutils import parseBiggestInt, parseBiggestUInt, parseBiggestFloat
 from strutils   import `%`, join, split, strip, toLowerAscii, cmpIgnoreStyle
-when NimVersion <= "0.19.4": import typetraits #$T -> system
+when NimVersion <= "0.19.8": import typetraits #$T -> system
 
 type
   ClHelpContext* = enum clLongOpt,      ## a long option identifier
@@ -386,7 +386,7 @@ proc argHelp*[T](dfl: set[T], a: var ArgcvtParams): seq[string]=
   result = @[ a.argKeys, typ, df ]
 
 # HashSets
-when NimVersion <= "0.19.4":
+when NimVersion <= "0.19.8":
   proc toHashSet[A](keys: openArray[A]): HashSet[A] = toSet[A](keys)
 
 proc argParse*[T](dst: var HashSet[T], dfl: HashSet[T],

--- a/cligen/textUt.nim
+++ b/cligen/textUt.nim
@@ -1,6 +1,6 @@
 from strutils import split, repeat, replace, count
 from terminal import terminalWidth
-when NimVersion <= "0.19.4":
+when NimVersion <= "0.19.8":
   import strutils
   proc wrapWords(x: string, maxLineWidth: int): string=wordWrap(x, maxLineWidth)
 else:

--- a/test/EchoResult.nim
+++ b/test/EchoResult.nim
@@ -1,5 +1,5 @@
 import cligen
-when NimVersion <= "0.19.4":
+when NimVersion <= "0.19.8":
   import editDistance
 else:
   import std/editDistance

--- a/test/HashSets.nim
+++ b/test/HashSets.nim
@@ -1,5 +1,5 @@
 import sets
-when NimVersion <= "0.19.4":
+when NimVersion <= "0.19.8":
   proc toHashSet[A](keys: openArray[A]): HashSet[A] = toSet[A](keys)
   proc initHashSet[A](initialSize=64): HashSet[A] = initSet[A](initialSize)
 

--- a/test/ResultInt.nim
+++ b/test/ResultInt.nim
@@ -1,5 +1,5 @@
 import cligen
-when NimVersion <= "0.19.4":
+when NimVersion <= "0.19.8":
   import editDistance
 else:
   import std/editDistance


### PR DESCRIPTION
cligen fails on 0.19.6

```
~/.nimble/pkgs/cligen-0.9.26/cligen/textUt.nim(7, 13) Error: cannot open file: std/wordwrap
```