### PR TITLE
allow const variables to be used as doc; fixes #110

### DIFF
--- a/cligen.nim
+++ b/cligen.nim
@@ -267,7 +267,7 @@ macro dispatchGen*(pro: typed{nkSym}, cmdName: string="", doc: string="",
   let impl = pro.getImpl
   if impl == nil: error "getImpl(" & $pro & ") returned nil."
   let fpars = formalParams(impl, toIdSeq(suppress))
-  var cmtDoc: string = $doc
+  var cmtDoc: string = if doc.kind == nnkStrLit: $doc else: doc.getImpl.strVal
   if cmtDoc.len == 0:                   # allow caller to override commentDoc
     collectComments(cmtDoc, impl)
     cmtDoc = strip(cmtDoc)


### PR DESCRIPTION
Signed-off-by: David Krause <david@code0.xyz>

i am by far an macro expert and this maybe has side effects that i'm unaware of.
But it seems to work.

```nim

import cligen
const help = """

  help
  ====
  my 
  help

"""

proc foo() = discard

dispatch(foo, doc = help)

```