### PR TITLE
Allow parsing cligen config from a TOML file

### DIFF
--- a/cligen/clCfgInit.nim
+++ b/cligen/clCfgInit.nim
@@ -1,101 +1,110 @@
 ## This is an ``include`` file used by ``cligen.nim`` proper to initialize the
 ## ``clCfg`` global.  Here we use only a config file to do so.
-import std/[parsecfg, streams, os, strutils, tables], cligen/humanUt
+import std/[os, strutils, tables], cligen/humanUt
 
-# Drive Nim stdlib parsecfg to apply .config/cligen|include files to `c`.
-proc apply(c: var ClCfg, path: string, plain=false) =
-  const yes = [ "t", "true" , "yes", "y", "1", "on" ]
-  var activeSection = "global"
-  template hl(x): string = specifierHighlight(x, Whitespace, keepPct=false,
-                                              termInAttr=false)
-  let relTo = path.parentDir & '/'
-  var f = newFileStream(path, fmRead)
-  if f == nil: return
-  var p: CfgParser
-  open(p, f, path)
-  while true:
-    var e = p.next
-    case e.kind
-    of cfgEof: break
-    of cfgSectionStart:
-      if e.section.startsWith("include__"):
-        let sub = e.section[9..^1]
-        let subp = if sub == sub.toUpperAscii: getEnv(sub) else: sub
-        c.apply(if subp.startsWith("/"): subp else: relTo & subp, plain)
-      else:
-        let sec = e.section.optionNormalize
-        case sec
-        of "global", "aliases", "layout", "syntax", "color", "templates":
-          activeSection = sec
-        else:
-          stderr.write path & ":" & " unknown section " & e.section & "\n" &
-            "Expecting: global aliases layout syntax color templates\n"
-          break
-    of cfgKeyValuePair, cfgOption:
-      case activeSection
-      of "global", "aliases":
-        case e.key.optionNormalize #I realize this can be simpler, but as-is it
-        of "colors":               #..allows darkBG symlink-> (lc|procs)/darkBG
-          let cols = e.value.split('=')
-          textAttrAlias(cols[0].strip, cols[1].strip)
-        else:
-          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
-                       "Can only be \"colors\"\n"
-      of "layout":
-        case e.key.optionNormalize
-        of "rowsep", "rowseparator": c.hTabRowSep = e.value
-        of "colgap", "columngap":    c.hTabColGap = parseInt(e.value)
-        of "minlast", "leastfinal":  c.hTabMinLast = parseInt(e.value)
-        of "cols", "columns":
-          c.hTabCols.setLen 0
-          for tok in e.value.split: c.hTabCols.add parseEnum[ClHelpCol](tok)
-        else:
-          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
-            "Expecting: rowseparator columngap leastfinal columns\n"
-      of "syntax":
-        case e.key.optionNormalize
-        of "reqsep", "requireseparator":
-          c.reqSep = e.value.optionNormalize in yes
-        of "sepchars", "separatorchars":
-          c.sepChars = {}; (for ch in e.value: c.sepChars.incl ch)
-        else:
-          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
-            "Expecting: requireseparator separatorchars\n"
-      of "color":
-        case e.key.optionNormalize
-        of "optkeys", "options", "switches", "optkey", "option", "switch":
-          if not plain: c.helpAttr["clOptKeys"] = textAttrOn(e.value.split)
-        of "valtypes", "valuetypes", "types", "valtype", "valuetype", "type":
-          if not plain: c.helpAttr["clValType"] = textAttrOn(e.value.split)
-        of "dflvals", "defaultvalues", "dflval", "defaultvalue":
-          if not plain: c.helpAttr["clDflVal"]  = textAttrOn(e.value.split)
-        of "descrips", "descriptions", "paramdescriptions", "descrip", "description", "paramdescription":
-          if not plain: c.helpAttr["clDescrip"] = textAttrOn(e.value.split)
-        of "cmd", "command", "cmdname", "commandname":
-          if not plain: c.helpAttr["cmd"] = textAttrOn(e.value.split)
-        of "doc", "documentation", "overalldocumentation":
-          if not plain: c.helpAttr["doc"] = textAttrOn(e.value.split)
-        of "args", "arguments", "argsonlinewithcmd":
-          if not plain: c.helpAttr["args"] = textAttrOn(e.value.split)
-        else:
-          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
-            "Expecting: options types defaultvalues descriptions command documentation arguments\n"
-      of "templates":
-        case e.key.optionNormalize
-        of "usehdr", "usageheader":  c.useHdr   = hl(e.value)
-        of "use", "usage":           c.use      = hl(e.value)
-        of "usemulti", "usagemulti": c.useMulti = hl(e.value)
-        else:
-          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
-            "Expecting: usageheader usage usagemulti\n"
-      else: discard # cannot happen since we break early above
-    of cfgError: echo e.msg
-  close(p)
+when defined(clCfgToml):
+  import std/[strformat, sequtils]
+  import parsetoml # nimble install parsetoml
+  const cgConfigFileBaseName = "config.toml"
+  include clCfgToml
+else:
+  import std/[streams, parsecfg]
+  const cgConfigFileBaseName = "config"
 
-var cfNm = getEnv("CLIGEN", os.getConfigDir() & "cligen/config")
+  # Drive Nim stdlib parsecfg to apply .config/cligen|include files to `c`.
+  proc apply(c: var ClCfg, path: string, plain=false) =
+    const yes = [ "t", "true" , "yes", "y", "1", "on" ]
+    var activeSection = "global"
+    template hl(x): string = specifierHighlight(x, Whitespace, keepPct=false,
+                                                termInAttr=false)
+    let relTo = path.parentDir & '/'
+    var f = newFileStream(path, fmRead)
+    if f == nil: return
+    var p: CfgParser
+    open(p, f, path)
+    while true:
+      var e = p.next
+      case e.kind
+      of cfgEof: break
+      of cfgSectionStart:
+        if e.section.startsWith("include__"):
+          let sub = e.section[9..^1]
+          let subp = if sub == sub.toUpperAscii: getEnv(sub) else: sub
+          c.apply(if subp.startsWith("/"): subp else: relTo & subp, plain)
+        else:
+          let sec = e.section.optionNormalize
+          case sec
+          of "global", "aliases", "layout", "syntax", "color", "templates":
+            activeSection = sec
+          else:
+            stderr.write path & ":" & " unknown section " & e.section & "\n" &
+              "Expecting: global aliases layout syntax color templates\n"
+            break
+      of cfgKeyValuePair, cfgOption:
+        case activeSection
+        of "global", "aliases":
+          case e.key.optionNormalize #I realize this can be simpler, but as-is it
+          of "colors":               #..allows darkBG symlink-> (lc|procs)/darkBG
+            let cols = e.value.split('=')
+            textAttrAlias(cols[0].strip, cols[1].strip)
+          else:
+            stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
+                         "Can only be \"colors\"\n"
+        of "layout":
+          case e.key.optionNormalize
+          of "rowsep", "rowseparator": c.hTabRowSep = e.value
+          of "colgap", "columngap":    c.hTabColGap = parseInt(e.value)
+          of "minlast", "leastfinal":  c.hTabMinLast = parseInt(e.value)
+          of "cols", "columns":
+            c.hTabCols.setLen 0
+            for tok in e.value.split: c.hTabCols.add parseEnum[ClHelpCol](tok)
+          else:
+            stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
+              "Expecting: rowseparator columngap leastfinal columns\n"
+        of "syntax":
+          case e.key.optionNormalize
+          of "reqsep", "requireseparator":
+            c.reqSep = e.value.optionNormalize in yes
+          of "sepchars", "separatorchars":
+            c.sepChars = {}; (for ch in e.value: c.sepChars.incl ch)
+          else:
+            stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
+              "Expecting: requireseparator separatorchars\n"
+        of "color":
+          case e.key.optionNormalize
+          of "optkeys", "options", "switches", "optkey", "option", "switch":
+            if not plain: c.helpAttr["clOptKeys"] = textAttrOn(e.value.split)
+          of "valtypes", "valuetypes", "types", "valtype", "valuetype", "type":
+            if not plain: c.helpAttr["clValType"] = textAttrOn(e.value.split)
+          of "dflvals", "defaultvalues", "dflval", "defaultvalue":
+            if not plain: c.helpAttr["clDflVal"]  = textAttrOn(e.value.split)
+          of "descrips", "descriptions", "paramdescriptions", "descrip", "description", "paramdescription":
+            if not plain: c.helpAttr["clDescrip"] = textAttrOn(e.value.split)
+          of "cmd", "command", "cmdname", "commandname":
+            if not plain: c.helpAttr["cmd"] = textAttrOn(e.value.split)
+          of "doc", "documentation", "overalldocumentation":
+            if not plain: c.helpAttr["doc"] = textAttrOn(e.value.split)
+          of "args", "arguments", "argsonlinewithcmd":
+            if not plain: c.helpAttr["args"] = textAttrOn(e.value.split)
+          else:
+            stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
+              "Expecting: options types defaultvalues descriptions command documentation arguments\n"
+        of "templates":
+          case e.key.optionNormalize
+          of "usehdr", "usageheader":  c.useHdr   = hl(e.value)
+          of "use", "usage":           c.use      = hl(e.value)
+          of "usemulti", "usagemulti": c.useMulti = hl(e.value)
+          else:
+            stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
+              "Expecting: usageheader usage usagemulti\n"
+        else: discard # cannot happen since we break early above
+      of cfgError: echo e.msg
+    close(p)
+
+var cfNm = getEnv("CLIGEN", os.getConfigDir() / "cligen" / cgConfigFileBaseName)
 if cfNm.existsFile: clCfg.apply(move(cfNm), existsEnv("NO_COLOR"))
-elif cfNm.endsWith("/config") and cfNm[0..^8].existsFile:
-  clCfg.apply(cfNm[0..^8], existsEnv("NO_COLOR"))
+elif cfNm.splitPath.head == "config" and (cfNm / cgConfigFileBaseName).existsFile:
+  clCfg.apply(cfNm / cgConfigFileBaseName, existsEnv("NO_COLOR"))
 # Any given end CL user likely wants just one global system of color aliases.
 # Default to leaving initial ones defined, but clear if an env.var says to.
 if existsEnv("CLIGEN_COLORS_CLEAR"): textAttrAliasClear()

--- a/cligen/clCfgToml.nim
+++ b/cligen/clCfgToml.nim
@@ -1,0 +1,82 @@
+# Use parsetoml to parse the config.toml files to the `ClCfg` object `c`.
+proc apply(c: var ClCfg, cfgFile: string, plain=false) =
+  template hl(x): string = specifierHighlight(x, Whitespace, keepPct=false,
+                                              termInAttr=false)
+  let
+    tomlCfg = parsetoml.parseFile(cfgFile).getTable()
+  for k1, v1 in tomlCfg.pairs:
+    case k1.toLowerAscii()
+    of "includes":
+      let
+        includeFiles = v1.getElems().mapIt(it.getStr())
+      for f in includeFiles:
+        if f == cfgFile: continue # disallow infinite loop
+        var f = f
+        if f == f.toUpperAscii(): f = getEnv(f)
+        if not f.startsWith('/'): f = cfgFile.parentDir() / f
+        if f.existsFile(): c.apply(f, plain)
+    of "global", "aliases":
+      for k2, v2 in v1.getTable().pairs:
+        case k2.toLowerAscii()
+        of "colors":
+          for k3, v3 in v2.getTable().pairs:
+            # echo &"    {k1}.{k2}.{k3} = {v3} "
+            textAttrAlias(k3, v3.getStr().strip())
+        else:
+          stderr.write(&"{cfgFile}: unknown keyword {k2} in the [{k1}] section\n")
+    of "layout":
+      for k2, v2 in v1.getTable().pairs:
+        case k2.toLowerAscii()
+        of "rowsep", "rowseparator": c.hTabRowSep = v2.getStr()
+        of "colgap", "columngap": c.hTabColGap = v2.getInt()
+        of "minlast", "leastfinal": c.hTabMinLast = v2.getInt()
+        of "cols", "columns":
+          c.hTabCols.setLen 0
+          for tok in v2.getElems().mapIt(it.getStr()): c.hTabCols.add parseEnum[ClHelpCol](tok)
+        else:
+          stderr.write(&"{cfgFile}: unknown keyword {k2} in the [{k1}] section\n")
+    of "syntax":
+      for k2, v2 in v1.getTable().pairs:
+        case k2.toLowerAscii()
+        of "reqsep", "requireseparator": c.reqSep = v2.getBool()
+        of "sepchars", "separatorchars":
+          c.sepChars = {}
+          for ch in v2.getElems().mapIt(it.getStr()[0]):
+            c.sepChars.incl(ch)
+        else:
+          stderr.write(&"{cfgFile}: unknown keyword {k2} in the [{k1}] section\n")
+    of "color":
+      if not plain:
+        for k2, v2 in v1.getTable().pairs:
+          let
+            colorStr = textAttrOn(v2.getElems().mapIt(it.getStr()))
+          case k2.toLowerAscii()
+          of "optkeys", "options", "switches", "optkey", "option", "switch":
+            c.helpAttr["clOptKeys"] = colorStr
+          of "valtypes", "valuetypes", "types", "valtype", "valuetype", "type":
+            c.helpAttr["clValType"] = colorStr
+          of "dflvals", "defaultvalues", "dflval", "defaultvalue":
+            c.helpAttr["clDflVal"] = colorStr
+          of "descrips", "descriptions", "paramdescriptions", "descrip", "description", "paramdescription":
+            c.helpAttr["clDescrip"] = colorStr
+          of "cmd", "command", "cmdname", "commandname":
+            c.helpAttr["cmd"] = colorStr
+          of "doc", "documentation", "overalldocumentation":
+            c.helpAttr["doc"] = colorStr
+          of "args", "arguments", "argsonlinewithcmd":
+            c.helpAttr["args"] = colorStr
+          else:
+            stderr.write(&"{cfgFile}: unknown keyword {k2} in the [{k1}] section\n")
+    of "templates":
+      for k2, v2 in v1.getTable().pairs:
+        let
+          templStr = v2.getStr().strip()
+        # echo &"  {k1}.{k2} = `{templStr}'"
+        case k2.toLowerAscii()
+        of "usageheader", "usehdr": c.useHdr = hl(templStr)
+        of "usage", "use": c.use = hl(templStr)
+        of "usagemulti", "usemulti": c.useMulti = hl(templStr)
+        else:
+          stderr.write(&"{cfgFile}: unknown keyword {k2} in the [{k1}] section\n")
+    else:
+      stderr.write(&"{cfgFile}: unknown keyword {k1}\n")


### PR DESCRIPTION
To enable reading from a TOML config file, the user needs to:

1. Install the parsetoml package using `nimble install parsetoml`
2. Compile the project using cligen with `-d:clCfgToml`

Default location for the TOML config file: ${XDG_CONFIG_HOME}/cligen/config.toml