### PR TITLE
Add precedence for config/config.toml lookup

### DIFF
--- a/cligen.nim
+++ b/cligen.nim
@@ -58,10 +58,7 @@ proc toInts*(x: seq[ClHelpCol]): seq[int] =
   ##Internal routine to convert help column enums to just ints for `alignTable`.
   for e in x: result.add(int(e))
 
-when defined(cgCfgToml):    # An include helpTmpl and syntaxHelp
-  include cligen/clCfgToml  # Trade parsetoml dependency for better documention
-else:
-  include cligen/clCfgInit  # Just use stdlib parsecfg
+include cligen/clCfgInit
 
 proc onCols*(c: ClCfg): seq[string] =
   ##Internal routine to map help table color specs to strings for `alignTable`.
@@ -1009,7 +1006,7 @@ macro initGen*(default: typed, T: untyped, positional="",
                              ident(($suppress[1][0])[10..^1]) else: nil
   let posId = ident(positional.strVal)
   var params = @[ quote do: `T` ] #Return type
-  var assigns = newStmtList()     #List of assignments 
+  var assigns = newStmtList()     #List of assignments
   if   indirect == 1: assigns.add(quote do: result.new)
   elif indirect == 2: assigns.add(quote do: result=cast[`T`](`T`.sizeof.alloc))
   for kid in ti.children:         #iterate over fields

--- a/cligen/clCfgInit.nim
+++ b/cligen/clCfgInit.nim
@@ -1,102 +1,29 @@
 ## This is an ``include`` file used by ``cligen.nim`` proper to initialize the
-## ``clCfg`` global.  Here we use only a parsecfg config file to do so.
+## ``clCfg`` global.
 
-import std/[streams,parsecfg, os,strutils,tables], cligen/humanUt
-const cgConfigFileBaseName = "config"
+when defined(cgCfgToml):
+  include cligen/clCfgInitToml # Trade parsetoml dependency for better documention
+else:
+  include cligen/clCfgInitDflt # Just use stdlib parsecfg
 
-proc apply(c: var ClCfg, path: string, plain=false) =
-  const yes = [ "t", "true" , "yes", "y", "1", "on" ]
-  var activeSection = "global"
-  template hl(x): string = specifierHighlight(x, Whitespace, plain,
-                                              keepPct=false, termInAttr=false)
-  let relTo = path.parentDir & '/'
-  var f = newFileStream(path, fmRead)
-  if f == nil: return
-  var p: CfgParser
-  open(p, f, path)
-  while true:
-    var e = p.next
-    case e.kind
-    of cfgEof: break
-    of cfgSectionStart:
-      if e.section.startsWith("include__"):
-        let sub = e.section[9..^1]
-        let subp = if sub == sub.toUpperAscii: getEnv(sub) else: sub
-        c.apply(if subp.startsWith("/"): subp else: relTo & subp, plain)
-      else:
-        let sec = e.section.optionNormalize
-        case sec
-        of "global", "aliases", "layout", "syntax", "color", "templates":
-          activeSection = sec
-        else:
-          stderr.write path & ":" & " unknown section " & e.section & "\n" &
-            "Expecting: global aliases layout syntax color templates\n"
-          break
-    of cfgKeyValuePair, cfgOption:
-      case activeSection
-      of "global", "aliases":
-        case e.key.optionNormalize #I realize this can be simpler, but as-is it
-        of "colors":               #..allows darkBG symlink-> (lc|procs)/darkBG
-          let cols = e.value.split('=')
-          textAttrAlias(cols[0].strip, cols[1].strip)
-        else:
-          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
-                       "Can only be \"colors\"\n"
-      of "layout":
-        case e.key.optionNormalize
-        of "rowsep", "rowseparator": c.hTabRowSep = e.value
-        of "colgap", "columngap":    c.hTabColGap = parseInt(e.value)
-        of "minlast", "leastfinal":  c.hTabMinLast = parseInt(e.value)
-        of "cols", "columns":
-          c.hTabCols.setLen 0
-          for tok in e.value.split: c.hTabCols.add parseEnum[ClHelpCol](tok)
-        else:
-          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
-            "Expecting: rowseparator columngap leastfinal columns\n"
-      of "syntax":
-        case e.key.optionNormalize
-        of "reqsep", "requireseparator":
-          c.reqSep = e.value.optionNormalize in yes
-        of "sepchars", "separatorchars":
-          c.sepChars = {}; (for ch in e.value: c.sepChars.incl ch)
-        else:
-          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
-            "Expecting: requireseparator separatorchars\n"
-      of "color":
-        case e.key.optionNormalize
-        of "optkeys", "options", "switches", "optkey", "option", "switch":
-          if not plain: c.helpAttr["clOptKeys"] = textAttrOn(e.value.split)
-        of "valtypes", "valuetypes", "types", "valtype", "valuetype", "type":
-          if not plain: c.helpAttr["clValType"] = textAttrOn(e.value.split)
-        of "dflvals", "defaultvalues", "dflval", "defaultvalue":
-          if not plain: c.helpAttr["clDflVal"]  = textAttrOn(e.value.split)
-        of "descrips", "descriptions", "paramdescriptions", "descrip", "description", "paramdescription":
-          if not plain: c.helpAttr["clDescrip"] = textAttrOn(e.value.split)
-        of "cmd", "command", "cmdname", "commandname":
-          if not plain: c.helpAttr["cmd"] = textAttrOn(e.value.split)
-        of "doc", "documentation", "overalldocumentation":
-          if not plain: c.helpAttr["doc"] = textAttrOn(e.value.split)
-        of "args", "arguments", "argsonlinewithcmd":
-          if not plain: c.helpAttr["args"] = textAttrOn(e.value.split)
-        else:
-          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
-            "Expecting: options types defaultvalues descriptions command documentation arguments\n"
-      of "templates":
-        case e.key.optionNormalize
-        of "usehdr", "usageheader":  c.useHdr   = hl(e.value)
-        of "use", "usage":           c.use      = hl(e.value)
-        of "usemulti", "usagemulti": c.useMulti = hl(e.value)
-        else:
-          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
-            "Expecting: usageheader usage usagemulti\n"
-      else: discard # cannot happen since we break early above
-    of cfgError: echo e.msg
-  close(p)
-
-var cfNm = getEnv("CLIGEN", os.getConfigDir()/"cligen"/cgConfigFileBaseName)
-if cfNm.existsFile: clCfg.apply(move(cfNm), existsEnv("NO_COLOR"))
-elif cfNm.splitPath.head == "config" and (cfNm/cgConfigFileBaseName).existsFile:
-  clCfg.apply(cfNm/cgConfigFileBaseName, existsEnv("NO_COLOR"))
+var cfNm = getEnv("CLIGEN")
+if not cfNm.existsFile:
+  let
+    cfgDir = os.getConfigDir()/"cligen"
+    configFileOptions = [cfgDir/"config",                # Parse using parsecfg
+                         cfgDir/"config"/"config",       # Parse using parsecfg
+                         cfgDir/"config.toml",           # Parse using parsetoml
+                         cfgDir/"config"/"config.toml"]  # Parse using parsetoml
+  cfNm = ""
+  for f in configFileOptions:
+    if f.existsFile:
+      cfNm = f
+      break
+if cfNm != "":
+  if cfNm.splitFile.ext == ".toml" and not defined(cgCfgToml):
+    stderr.write("Config file $1 detected. Ensure that 'parsetoml' module is installed from nimble, compile with -d:cgCfgToml\n" % [cfNm])
+    quit QuitFailure
+  clCfg.apply(move(cfNm), existsEnv("NO_COLOR"))
 # Any given end CL user likely wants just one global system of color aliases.
 # Default to leaving initial ones defined, but clear if an env.var says to.
 if existsEnv("CLIGEN_COLORS_CLEAR"): textAttrAliasClear()

--- a/cligen/clCfgInitDflt.nim
+++ b/cligen/clCfgInitDflt.nim
@@ -1,0 +1,93 @@
+## This is an ``include`` file used by ``clCfgInit.nim`` proper to initialize the
+## ``clCfg`` global.  Here we use only a parsecfg config file to do so.
+
+import std/[streams,parsecfg, os,strutils,tables], cligen/humanUt
+
+proc apply(c: var ClCfg, path: string, plain=false) =
+  const yes = [ "t", "true" , "yes", "y", "1", "on" ]
+  var activeSection = "global"
+  template hl(x): string = specifierHighlight(x, Whitespace, plain,
+                                              keepPct=false, termInAttr=false)
+  let relTo = path.parentDir & '/'
+  var f = newFileStream(path, fmRead)
+  if f == nil: return
+  var p: CfgParser
+  open(p, f, path)
+  while true:
+    var e = p.next
+    case e.kind
+    of cfgEof: break
+    of cfgSectionStart:
+      if e.section.startsWith("include__"):
+        let sub = e.section[9..^1]
+        let subp = if sub == sub.toUpperAscii: getEnv(sub) else: sub
+        c.apply(if subp.startsWith("/"): subp else: relTo & subp, plain)
+      else:
+        let sec = e.section.optionNormalize
+        case sec
+        of "global", "aliases", "layout", "syntax", "color", "templates":
+          activeSection = sec
+        else:
+          stderr.write path & ":" & " unknown section " & e.section & "\n" &
+            "Expecting: global aliases layout syntax color templates\n"
+          break
+    of cfgKeyValuePair, cfgOption:
+      case activeSection
+      of "global", "aliases":
+        case e.key.optionNormalize #I realize this can be simpler, but as-is it
+        of "colors":               #..allows darkBG symlink-> (lc|procs)/darkBG
+          let cols = e.value.split('=')
+          textAttrAlias(cols[0].strip, cols[1].strip)
+        else:
+          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
+                       "Can only be \"colors\"\n"
+      of "layout":
+        case e.key.optionNormalize
+        of "rowsep", "rowseparator": c.hTabRowSep = e.value
+        of "colgap", "columngap":    c.hTabColGap = parseInt(e.value)
+        of "minlast", "leastfinal":  c.hTabMinLast = parseInt(e.value)
+        of "cols", "columns":
+          c.hTabCols.setLen 0
+          for tok in e.value.split: c.hTabCols.add parseEnum[ClHelpCol](tok)
+        else:
+          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
+            "Expecting: rowseparator columngap leastfinal columns\n"
+      of "syntax":
+        case e.key.optionNormalize
+        of "reqsep", "requireseparator":
+          c.reqSep = e.value.optionNormalize in yes
+        of "sepchars", "separatorchars":
+          c.sepChars = {}; (for ch in e.value: c.sepChars.incl ch)
+        else:
+          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
+            "Expecting: requireseparator separatorchars\n"
+      of "color":
+        case e.key.optionNormalize
+        of "optkeys", "options", "switches", "optkey", "option", "switch":
+          if not plain: c.helpAttr["clOptKeys"] = textAttrOn(e.value.split)
+        of "valtypes", "valuetypes", "types", "valtype", "valuetype", "type":
+          if not plain: c.helpAttr["clValType"] = textAttrOn(e.value.split)
+        of "dflvals", "defaultvalues", "dflval", "defaultvalue":
+          if not plain: c.helpAttr["clDflVal"]  = textAttrOn(e.value.split)
+        of "descrips", "descriptions", "paramdescriptions", "descrip", "description", "paramdescription":
+          if not plain: c.helpAttr["clDescrip"] = textAttrOn(e.value.split)
+        of "cmd", "command", "cmdname", "commandname":
+          if not plain: c.helpAttr["cmd"] = textAttrOn(e.value.split)
+        of "doc", "documentation", "overalldocumentation":
+          if not plain: c.helpAttr["doc"] = textAttrOn(e.value.split)
+        of "args", "arguments", "argsonlinewithcmd":
+          if not plain: c.helpAttr["args"] = textAttrOn(e.value.split)
+        else:
+          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
+            "Expecting: options types defaultvalues descriptions command documentation arguments\n"
+      of "templates":
+        case e.key.optionNormalize
+        of "usehdr", "usageheader":  c.useHdr   = hl(e.value)
+        of "use", "usage":           c.use      = hl(e.value)
+        of "usemulti", "usagemulti": c.useMulti = hl(e.value)
+        else:
+          stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
+            "Expecting: usageheader usage usagemulti\n"
+      else: discard # cannot happen since we break early above
+    of cfgError: echo e.msg
+  close(p)

--- a/cligen/clCfgInitToml.nim
+++ b/cligen/clCfgInitToml.nim
@@ -1,9 +1,8 @@
-## This is an ``include`` file used by ``cligen.nim`` proper to initialize the
+## This is an ``include`` file used by ``clCfgInit.nim`` proper to initialize the
 ## ``clCfg`` global.  Here we use only a TOML config file to do so.  You must
 ## add parsetoml to your compile setup via nimble install parsetoml or elsewise.
 
 import std/[strformat,sequtils, os,strutils,tables], cligen/humanUt, parsetoml
-const cgConfigFileBaseName = "config.toml"
 
 proc apply(c: var ClCfg, cfgFile: string, plain=false) =
   template hl(x): string = specifierHighlight(x, Whitespace, plain,
@@ -86,11 +85,3 @@ proc apply(c: var ClCfg, cfgFile: string, plain=false) =
           stderr.write(&"{cfgFile}: unknown keyword {k2} in the [{k1}] section\n")
     else:
       stderr.write(&"{cfgFile}: unknown keyword {k1}\n")
-
-var cfNm = getEnv("CLIGEN", os.getConfigDir()/"cligen"/cgConfigFileBaseName)
-if cfNm.existsFile: clCfg.apply(move(cfNm), existsEnv("NO_COLOR"))
-elif cfNm.splitPath.head == "config" and (cfNm/cgConfigFileBaseName).existsFile:
-  clCfg.apply(cfNm/cgConfigFileBaseName, existsEnv("NO_COLOR"))
-# Any given end CL user likely wants just one global system of color aliases.
-# Default to leaving initial ones defined, but clear if an env.var says to.
-if existsEnv("CLIGEN_COLORS_CLEAR"): textAttrAliasClear()


### PR DESCRIPTION
Add a useful error message if config.toml is found, but the project is
not compiled with parsetoml.

Ref: https://github.com/c-blake/cligen/pull/141#issuecomment-624030900