### PR TITLE
Support proc params as sym

### DIFF
--- a/cligen/macUt.nim
+++ b/cligen/macUt.nim
@@ -130,7 +130,10 @@ macro docFromProc*(sym: typed{nkSym}): untyped =
 
 proc maybeDestrop*(id: NimNode): NimNode =
   ## Used to remove stropping backticks \`\`, if present, from an ident node
-  if id.kind == nnkAccQuoted: id[0] else: id
+  case id.kind
+  of nnkAccQuoted: id[0] 
+  of nnkSym: newIdentNode($id)
+  else: id
 
 macro with*(ob: typed, fields: untyped, body: untyped): untyped =
   ## Usage ``with(ob, [ f1, f2, ... ]): body`` where ``ob`` is any expression


### PR DESCRIPTION
Upcoming changes to Nim compiler will make proc params symbols instead of idents. Package tests showed cligen changes are required.

https://github.com/nim-lang/Nim/pull/15252

https://github.com/nim-lang/Nim/pull/15332
