### PR TITLE
fix test script #165

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           path: ~/.nimble
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
-      - uses: jiro4989/setup-nim-action@v1.0.2
+      - uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: 'devel --latest'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           path: ~/.nimble
           key: ${{ runner.os }}-nimble-${{ hashFiles('*.nimble') }}
-      - uses: jiro4989/setup-nim-action@v1.0.2
+      - uses: jiro4989/setup-nim-action@v1
         with:
           nim-version: ${{ matrix.nim_version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macOS-latest
+          # - macOS-latest # no devel-compiler of mac
           # - windows-latest # FIXME
         nim_version:
           - 'devel'

--- a/test.sh
+++ b/test.sh
@@ -8,6 +8,7 @@ for n in test/[A-Z]*.nim; do
   c=$HOME/.cache/nim/cache-${n%.nim}
   ${nim:-nim} ${BE:-c} --nimcache:$c "$@" --run $n --help 2>&1 |
     grep -v '^CC:' |
+    grep -v '^\.CC:' |
     grep -Ev '^\.{8}' > $o &
 done
 wait

--- a/test.sh
+++ b/test.sh
@@ -3,24 +3,18 @@ exec < /dev/null
 export COLUMNS=80
 export CLIGEN=/dev/null
 rm -rf $HOME/.cache/nim/*
-
-for n in test/[A-Z]*.nim; do
-  c=$HOME/.cache/nim/cache-${n%.nim}
-  ${nim:-nim} ${BE:-c} --nimcache:$c "$@" $n
-done
-
 for n in test/[A-Z]*.nim; do
   o=${n%.nim}.out
-  cmd=${n%.nim}
-  "./$cmd" --help > "$o" 2>&1 &
+  c=$HOME/.cache/nim/cache-${n%.nim}
+  ${nim:-nim} ${BE:-c} --nimcache:$c "$@" --run $n --help 2>&1 |
+    grep -v '^CC:' > $o &
 done
 wait
-
 ./test/FullyAutoMulti help > test/FullyAutoMultiTopLvl.out 2>&1
 ./test/MultiMulti help > test/MultiMultiTopLvl.out 2>&1
 head -n900 test/*.out | grep -v '^Hint: ' |
-  sed -e 's@.*/cligen.nim(@cligen.nim(@' \
-    -e 's@.*/cligen/@cligen/@' \
-    -e 's@.*/test/@test/@' > test/out
+     sed -e 's@.*/cligen.nim(@cligen.nim(@' \
+         -e 's@.*/cligen/@cligen/@' \
+         -e 's@.*/test/@test/@' > test/out
 rm -f test/*.out
 diff test/ref test/out

--- a/test.sh
+++ b/test.sh
@@ -24,4 +24,3 @@ head -n900 test/*.out | grep -v '^Hint: ' |
     -e 's@.*/test/@test/@' > test/out
 rm -f test/*.out
 diff test/ref test/out
-exit 0

--- a/test.sh
+++ b/test.sh
@@ -3,19 +3,25 @@ exec < /dev/null
 export COLUMNS=80
 export CLIGEN=/dev/null
 rm -rf $HOME/.cache/nim/*
+
+for n in test/[A-Z]*.nim; do
+  c=$HOME/.cache/nim/cache-${n%.nim}
+  ${nim:-nim} ${BE:-c} --nimcache:$c "$@" $n
+done
+
 for n in test/[A-Z]*.nim; do
   o=${n%.nim}.out
-  c=$HOME/.cache/nim/cache-${n%.nim}
-  ${nim:-nim} ${BE:-c} --nimcache:$c "$@" --run $n --help 2>&1 |
-    grep -v '^CC:' > $o &
+  cmd=${n%.nim}
+  "./$cmd" --help > "$o" 2>&1 &
 done
 wait
+
 ./test/FullyAutoMulti help > test/FullyAutoMultiTopLvl.out 2>&1
 ./test/MultiMulti help > test/MultiMultiTopLvl.out 2>&1
 head -n900 test/*.out | grep -v '^Hint: ' |
-     sed -e 's@.*/cligen.nim(@cligen.nim(@' \
-         -e 's@.*/cligen/@cligen/@' \
-         -e 's@.*/test/@test/@' > test/out
+  sed -e 's@.*/cligen.nim(@cligen.nim(@' \
+    -e 's@.*/cligen/@cligen/@' \
+    -e 's@.*/test/@test/@' > test/out
 rm -f test/*.out
 diff test/ref test/out
 exit 0

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,8 @@ for n in test/[A-Z]*.nim; do
   o=${n%.nim}.out
   c=$HOME/.cache/nim/cache-${n%.nim}
   ${nim:-nim} ${BE:-c} --nimcache:$c "$@" --run $n --help 2>&1 |
-    grep -v '^CC:' > $o &
+    grep -v '^CC:' |
+    grep -Ev '^\.{8}' > $o &
 done
 wait
 ./test/FullyAutoMulti help > test/FullyAutoMultiTopLvl.out 2>&1

--- a/test/ref
+++ b/test/ref
@@ -826,6 +826,9 @@ Options:
   -b=, --beta=   float  2.0  shrink target
 
 ==> test/TwoNondefaultedSeq.out <==
+test/TwoNondefaultedSeq.nim(9, 11) template/generic instantiation of `dispatch` from here
+cligen.nim(768, 14) template/generic instantiation of `dispatchCf` from here
+cligen.nim(755, 14) template/generic instantiation of `dispatchGen` from here
 Usage:
   demo [required&optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.

--- a/test/ref
+++ b/test/ref
@@ -826,9 +826,6 @@ Options:
   -b=, --beta=   float  2.0  shrink target
 
 ==> test/TwoNondefaultedSeq.out <==
-test/TwoNondefaultedSeq.nim(9, 11) template/generic instantiation of `dispatch` from here
-cligen.nim(768, 14) template/generic instantiation of `dispatchCf` from here
-cligen.nim(755, 14) template/generic instantiation of `dispatchGen` from here
 Usage:
   demo [required&optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.

--- a/test/ref
+++ b/test/ref
@@ -1,5 +1,4 @@
 ==> test/AllSeqTypes.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with parameters of all basic types.
@@ -36,7 +35,6 @@ Options:
   --F8=          float64s  25.0,26.0   append 1 val to F8
 
 ==> test/AllSetTypes.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with parameters of all basic types.
@@ -57,7 +55,6 @@ Options:
   -E=, --E=      set(Color)   red,green,blue  include 1 val in E
 
 ==> test/AllTypes.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with parameters of all basic types.
@@ -83,7 +80,6 @@ Options:
   -q=, --qq=     float    13.0   set qq
 
 ==> test/BlockedShort.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] 
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -98,7 +94,6 @@ Options:
   --aloha=       string  ""     set aloha
 
 ==> test/CustomCmdName.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   deeeemo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -113,7 +108,6 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/CustomType.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -127,7 +121,6 @@ Options:
   -s=, --stuff=  CSV   "ab,cd"  append 1 val to stuff
 
 ==> test/DetectSet.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   foo [optional-params] 
 Options:
@@ -137,7 +130,6 @@ Options:
   -b=, --beta=   int  2  set beta
 
 ==> test/DistinctInt.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   main [required&optional-params] 
 Options:
@@ -146,7 +138,6 @@ Options:
   -a=, --age=    int  REQUIRED  set age
 
 ==> test/DupShort.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] 
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -161,7 +152,6 @@ Options:
   --aloha=       string  ""     set aloha
 
 ==> test/EarlySeq.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -176,7 +166,6 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/EchoResult.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   editDistanceAscii [required&optional-params] 
 Returns the edit distance between `a` and `b`.
@@ -190,7 +179,6 @@ Options:
   -b=, --b=      string  REQUIRED  set b
 
 ==> test/Enums.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.
@@ -204,7 +192,6 @@ Options:
   -x=, --x=      int         0         set x
 
 ==> test/External.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -219,7 +206,6 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/FancyRepeats.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -234,7 +220,6 @@ Options:
   -s=, --stuff=  strings  ab,cd  append 1 val to stuff
 
 ==> test/FancyRepeats2.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -249,7 +234,6 @@ Options:
   -s=, --stuff=  strings  ab,cd  append 1 val to stuff
 
 ==> test/FullyAutoMulti.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Infer & generate command-line interace/option/argument parser
 Usage:
   FullyAutoMulti {SUBCMD}  [sub-command options & parameters]
@@ -309,7 +293,6 @@ where subcommand syntaxes are as follows:
       -v, --verb     bool  false  set verb
 
 ==> test/HashSets.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with parameters of all basic types.
@@ -328,7 +311,6 @@ Options:
   -E=, --E=      hashset(Color)   red,blue  include 1 val in E
 
 ==> test/HelpTabCols.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -343,7 +325,6 @@ Options:
   -i=, --item=   set item                       ""
 
 ==> test/ImplicitDefault.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -357,7 +338,6 @@ Options:
   -i=, --iteM=   string  ""        set iteM
 
 ==> test/InitOb.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   InitOb [optional-params] [iters: int (loops per slot)]
 do some app
@@ -368,7 +348,6 @@ Options:
   -s, --show     bool    false    show informative compiler info
 
 ==> test/InitObPtr.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   InitOb [optional-params] [iters: int (loops per slot)]
 do some app
@@ -379,7 +358,6 @@ Options:
   -s, --show     bool    false    show informative compiler info
 
 ==> test/InitObRef.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   InitOb [optional-params] [iters: int (loops per slot)]
 do some app
@@ -390,7 +368,6 @@ Options:
   -s, --show     bool    false    show informative compiler info
 
 ==> test/InitTup.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   InitOb [optional-params] 
 do some app
@@ -402,7 +379,6 @@ Options:
   -S, --show       bool    false    show informative compiler info
 
 ==> test/ListDecl.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] [args: int...]
 demo entry point with varied, meaningless parameters.
@@ -414,7 +390,6 @@ Options:
   -v, --verb     bool   false     set verb
 
 ==> test/Mandatory.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -429,7 +404,6 @@ Options:
   -i=, --item=   string  REQUIRED  set item
 
 ==> test/MandatoryNoPos.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] 
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -444,7 +418,6 @@ Options:
   -i=, --item=   string  REQUIRED  set item
 
 ==> test/ManualMulti.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   ManualMulti demo|show [subcommand-args]
 
@@ -478,7 +451,6 @@ Usage:
           -v, --verb     bool   false  set verb
 
 ==> test/MultMultMult.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 module doc
 Usage:
   MultMultMult {SUBCMD}  [sub-command options & parameters]
@@ -495,7 +467,6 @@ Run "MultMultMult help" to get *comprehensive* help.
 Top-level --version also available
 
 ==> test/MultiFlag.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.
@@ -507,7 +478,6 @@ Options:
   -v, --verb     bool  false  set verb
 
 ==> test/MultiMulti.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 NAME
   Test sub-sub-command CLI instantiation.
 USAGE
@@ -554,7 +524,6 @@ where subcommand syntaxes are as follows:
       -v, --verb     bool  false  set verb
 
 ==> test/NoPositional.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] 
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -569,7 +538,6 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/NoShort.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] 
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -584,7 +552,6 @@ Options:
   --aloha=       string  ""     set aloha
 
 ==> test/OmitInHelpTable.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -599,7 +566,6 @@ Options:
   -i=, --item=    string  ""     set item
 
 ==> test/OneCharLong.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   test [optional-params] 
 Options:
@@ -610,7 +576,6 @@ Options:
   -s=, --s=      string  ""  set s
 
 ==> test/OneCharParams.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [b: string...]
 This tests if single character parameters work as expected
@@ -622,7 +587,6 @@ Options:
   -g=, --g=      string  "ho"        set g
 
 ==> test/ParseOnly.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 fooParse:
   (paramName: "help", unparsedVal: "", message: "Usage:\n  foo [required&optional-params] [rest: int...]\nOptions:\n  -h, --help                    print this cligen-erated help\n  --help-syntax                 advanced: prepend,plurals,..\n  -a=, --alpha=  int  REQUIRED  set alpha\n  -b=, --beta=   int  2         set beta\n", status: clHelpOnly)
   (paramName: "alpha", unparsedVal: "", message: "Missing alpha", status: clMissing)
@@ -638,7 +602,6 @@ Options:
 
 
 ==> test/PassValues.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   myCmd [optional-params] [a1: string...]
 The doc
@@ -651,7 +614,6 @@ Options:
   -a=, --a2=      strings  {}   append 1 val to a2
 
 ==> test/PassValuesMulti.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Infer & generate command-line interace/option/argument parser
 Usage:
   PassValuesMulti {SUBCMD}  [sub-command options & parameters]
@@ -670,7 +632,6 @@ Run "PassValuesMulti help" to get *comprehensive* help.
 Top-level --version also available
 
 ==> test/PerParam.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -685,7 +646,6 @@ Options:
   -i=, --item=    string  ""     set item
 
 ==> test/QualifiedMulti.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   QualifiedMulti {SUBCMD}  [sub-command options & parameters]
 where {SUBCMD} is one of:
@@ -699,7 +659,6 @@ Run "QualifiedMulti {help SUBCMD|SUBCMD --help}" to see help for just SUBCMD.
 Run "QualifiedMulti help" to get *comprehensive* help.
 
 ==> test/QualifiedSym.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   get [optional-params] 
 Options:
@@ -708,7 +667,6 @@ Options:
   -a=, --a=      int  1  set a
 
 ==> test/ResultInt.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   editDistanceAscii [required&optional-params] 
 Returns the edit distance between `a` and `b`.
@@ -723,7 +681,6 @@ Options:
   -b=, --b=      string  REQUIRED  set b
 
 ==> test/ReturnEmpty.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -738,7 +695,6 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/ReturnInt.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -753,7 +709,6 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/ReturnNonInt.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -768,7 +723,6 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/ReturnNonIntNoAuto.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -783,7 +737,6 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/ReturnString.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -798,7 +751,6 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/SemiAutoMulti.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   multi [optional-params] [subCmd: string...]
 Run command with no parameters for a full help message.
@@ -807,7 +759,6 @@ Options:
   --help-syntax      advanced: prepend,plurals,..
 
 ==> test/SemiMultMult.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   multi [optional-params] [cmdLine: string...]
 Run command with no parameters for a full help message.
@@ -816,7 +767,6 @@ Options:
   --help-syntax      advanced: prepend,plurals,..
 
 ==> test/SeqInt.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: int...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -831,7 +781,6 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/SetByParse.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   foo [optional-params] [rest: int...]
 Options:
@@ -841,7 +790,6 @@ Options:
   -b=, --beta=   int    2    set beta
 
 ==> test/StroppedParams.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   repro [optional-params] 
 Options:
@@ -853,7 +801,6 @@ Options:
   -b, --b                bool  false  single letter parameters don't suffer
 
 ==> test/SubScope.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   SubScope {SUBCMD}  [sub-command options & parameters]
 where {SUBCMD} is one of:
@@ -867,7 +814,6 @@ Run "SubScope {help SUBCMD|SUBCMD --help}" to see help for just SUBCMD.
 Run "SubScope help" to get *comprehensive* help.
 
 ==> test/Suppress.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -880,11 +826,9 @@ Options:
   -b=, --beta=   float  2.0  shrink target
 
 ==> test/TwoNondefaultedSeq.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 test/TwoNondefaultedSeq.nim(9, 11) template/generic instantiation of `dispatch` from here
 cligen.nim(768, 14) template/generic instantiation of `dispatchCf` from here
 cligen.nim(755, 14) template/generic instantiation of `dispatchGen` from here
-cligen.nim(243, 16) Warning: cligen only supports one seq param for positional args; using `args`, not `stuff`.  Use `positional` parameter to `dispatch` to override this. [User]
 Usage:
   demo [required&optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.
@@ -896,7 +840,6 @@ Options:
   -s=, --stuff=  strings  REQUIRED  append 1 val to stuff
 
 ==> test/TwoNondefaultedSeqSwap.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] [ stuff (0 or more strings) ]
 demo entry point with varied, meaningless parameters.
@@ -908,7 +851,6 @@ Options:
   --args=        strings  REQUIRED  append 1 val to args
 
 ==> test/UserAliases.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   UserAliases [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters with an alias system.
@@ -925,7 +867,6 @@ Options:
   -i=, --item=    string  ""     set item
 
 ==> test/UserDispIdCollide.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 This tests if things work when a wrapped user-proc uses identifiers also used in
@@ -938,7 +879,6 @@ Options:
   -g=, --getopt=   string  "ho"        set getopt
 
 ==> test/Version.out <==
-cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   Version [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might

--- a/test/ref
+++ b/test/ref
@@ -1,4 +1,5 @@
 ==> test/AllSeqTypes.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with parameters of all basic types.
@@ -35,6 +36,7 @@ Options:
   --F8=          float64s  25.0,26.0   append 1 val to F8
 
 ==> test/AllSetTypes.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with parameters of all basic types.
@@ -55,6 +57,7 @@ Options:
   -E=, --E=      set(Color)   red,green,blue  include 1 val in E
 
 ==> test/AllTypes.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with parameters of all basic types.
@@ -80,6 +83,7 @@ Options:
   -q=, --qq=     float    13.0   set qq
 
 ==> test/BlockedShort.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] 
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -94,6 +98,7 @@ Options:
   --aloha=       string  ""     set aloha
 
 ==> test/CustomCmdName.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   deeeemo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -108,6 +113,7 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/CustomType.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -121,6 +127,7 @@ Options:
   -s=, --stuff=  CSV   "ab,cd"  append 1 val to stuff
 
 ==> test/DetectSet.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   foo [optional-params] 
 Options:
@@ -130,6 +137,7 @@ Options:
   -b=, --beta=   int  2  set beta
 
 ==> test/DistinctInt.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   main [required&optional-params] 
 Options:
@@ -138,6 +146,7 @@ Options:
   -a=, --age=    int  REQUIRED  set age
 
 ==> test/DupShort.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] 
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -152,6 +161,7 @@ Options:
   --aloha=       string  ""     set aloha
 
 ==> test/EarlySeq.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -166,6 +176,7 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/EchoResult.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   editDistanceAscii [required&optional-params] 
 Returns the edit distance between `a` and `b`.
@@ -179,6 +190,7 @@ Options:
   -b=, --b=      string  REQUIRED  set b
 
 ==> test/Enums.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.
@@ -192,6 +204,7 @@ Options:
   -x=, --x=      int         0         set x
 
 ==> test/External.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -206,6 +219,7 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/FancyRepeats.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -220,6 +234,7 @@ Options:
   -s=, --stuff=  strings  ab,cd  append 1 val to stuff
 
 ==> test/FancyRepeats2.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -234,6 +249,7 @@ Options:
   -s=, --stuff=  strings  ab,cd  append 1 val to stuff
 
 ==> test/FullyAutoMulti.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Infer & generate command-line interace/option/argument parser
 Usage:
   FullyAutoMulti {SUBCMD}  [sub-command options & parameters]
@@ -293,6 +309,7 @@ where subcommand syntaxes are as follows:
       -v, --verb     bool  false  set verb
 
 ==> test/HashSets.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with parameters of all basic types.
@@ -311,6 +328,7 @@ Options:
   -E=, --E=      hashset(Color)   red,blue  include 1 val in E
 
 ==> test/HelpTabCols.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -325,6 +343,7 @@ Options:
   -i=, --item=   set item                       ""
 
 ==> test/ImplicitDefault.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -338,6 +357,7 @@ Options:
   -i=, --iteM=   string  ""        set iteM
 
 ==> test/InitOb.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   InitOb [optional-params] [iters: int (loops per slot)]
 do some app
@@ -348,6 +368,7 @@ Options:
   -s, --show     bool    false    show informative compiler info
 
 ==> test/InitObPtr.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   InitOb [optional-params] [iters: int (loops per slot)]
 do some app
@@ -358,6 +379,7 @@ Options:
   -s, --show     bool    false    show informative compiler info
 
 ==> test/InitObRef.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   InitOb [optional-params] [iters: int (loops per slot)]
 do some app
@@ -368,6 +390,7 @@ Options:
   -s, --show     bool    false    show informative compiler info
 
 ==> test/InitTup.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   InitOb [optional-params] 
 do some app
@@ -379,6 +402,7 @@ Options:
   -S, --show       bool    false    show informative compiler info
 
 ==> test/ListDecl.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] [args: int...]
 demo entry point with varied, meaningless parameters.
@@ -390,6 +414,7 @@ Options:
   -v, --verb     bool   false     set verb
 
 ==> test/Mandatory.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -404,6 +429,7 @@ Options:
   -i=, --item=   string  REQUIRED  set item
 
 ==> test/MandatoryNoPos.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] 
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -418,6 +444,7 @@ Options:
   -i=, --item=   string  REQUIRED  set item
 
 ==> test/ManualMulti.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   ManualMulti demo|show [subcommand-args]
 
@@ -451,6 +478,7 @@ Usage:
           -v, --verb     bool   false  set verb
 
 ==> test/MultMultMult.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 module doc
 Usage:
   MultMultMult {SUBCMD}  [sub-command options & parameters]
@@ -467,6 +495,7 @@ Run "MultMultMult help" to get *comprehensive* help.
 Top-level --version also available
 
 ==> test/MultiFlag.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.
@@ -478,6 +507,7 @@ Options:
   -v, --verb     bool  false  set verb
 
 ==> test/MultiMulti.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 NAME
   Test sub-sub-command CLI instantiation.
 USAGE
@@ -524,6 +554,7 @@ where subcommand syntaxes are as follows:
       -v, --verb     bool  false  set verb
 
 ==> test/NoPositional.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] 
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -538,6 +569,7 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/NoShort.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] 
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -552,6 +584,7 @@ Options:
   --aloha=       string  ""     set aloha
 
 ==> test/OmitInHelpTable.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -566,6 +599,7 @@ Options:
   -i=, --item=    string  ""     set item
 
 ==> test/OneCharLong.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   test [optional-params] 
 Options:
@@ -576,6 +610,7 @@ Options:
   -s=, --s=      string  ""  set s
 
 ==> test/OneCharParams.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [b: string...]
 This tests if single character parameters work as expected
@@ -587,6 +622,7 @@ Options:
   -g=, --g=      string  "ho"        set g
 
 ==> test/ParseOnly.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 fooParse:
   (paramName: "help", unparsedVal: "", message: "Usage:\n  foo [required&optional-params] [rest: int...]\nOptions:\n  -h, --help                    print this cligen-erated help\n  --help-syntax                 advanced: prepend,plurals,..\n  -a=, --alpha=  int  REQUIRED  set alpha\n  -b=, --beta=   int  2         set beta\n", status: clHelpOnly)
   (paramName: "alpha", unparsedVal: "", message: "Missing alpha", status: clMissing)
@@ -602,6 +638,7 @@ Options:
 
 
 ==> test/PassValues.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   myCmd [optional-params] [a1: string...]
 The doc
@@ -614,6 +651,7 @@ Options:
   -a=, --a2=      strings  {}   append 1 val to a2
 
 ==> test/PassValuesMulti.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Infer & generate command-line interace/option/argument parser
 Usage:
   PassValuesMulti {SUBCMD}  [sub-command options & parameters]
@@ -632,6 +670,7 @@ Run "PassValuesMulti help" to get *comprehensive* help.
 Top-level --version also available
 
 ==> test/PerParam.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -646,6 +685,7 @@ Options:
   -i=, --item=    string  ""     set item
 
 ==> test/QualifiedMulti.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   QualifiedMulti {SUBCMD}  [sub-command options & parameters]
 where {SUBCMD} is one of:
@@ -659,6 +699,7 @@ Run "QualifiedMulti {help SUBCMD|SUBCMD --help}" to see help for just SUBCMD.
 Run "QualifiedMulti help" to get *comprehensive* help.
 
 ==> test/QualifiedSym.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   get [optional-params] 
 Options:
@@ -667,6 +708,7 @@ Options:
   -a=, --a=      int  1  set a
 
 ==> test/ResultInt.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   editDistanceAscii [required&optional-params] 
 Returns the edit distance between `a` and `b`.
@@ -681,6 +723,7 @@ Options:
   -b=, --b=      string  REQUIRED  set b
 
 ==> test/ReturnEmpty.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -695,6 +738,7 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/ReturnInt.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -709,6 +753,7 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/ReturnNonInt.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -723,6 +768,7 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/ReturnNonIntNoAuto.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -737,6 +783,7 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/ReturnString.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -751,6 +798,7 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/SemiAutoMulti.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   multi [optional-params] [subCmd: string...]
 Run command with no parameters for a full help message.
@@ -759,6 +807,7 @@ Options:
   --help-syntax      advanced: prepend,plurals,..
 
 ==> test/SemiMultMult.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   multi [optional-params] [cmdLine: string...]
 Run command with no parameters for a full help message.
@@ -767,6 +816,7 @@ Options:
   --help-syntax      advanced: prepend,plurals,..
 
 ==> test/SeqInt.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: int...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -781,6 +831,7 @@ Options:
   -i=, --item=   string  ""     set item
 
 ==> test/SetByParse.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   foo [optional-params] [rest: int...]
 Options:
@@ -790,6 +841,7 @@ Options:
   -b=, --beta=   int    2    set beta
 
 ==> test/StroppedParams.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   repro [optional-params] 
 Options:
@@ -801,6 +853,7 @@ Options:
   -b, --b                bool  false  single letter parameters don't suffer
 
 ==> test/SubScope.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   SubScope {SUBCMD}  [sub-command options & parameters]
 where {SUBCMD} is one of:
@@ -814,6 +867,7 @@ Run "SubScope {help SUBCMD|SUBCMD --help}" to see help for just SUBCMD.
 Run "SubScope help" to get *comprehensive* help.
 
 ==> test/Suppress.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might
@@ -826,9 +880,11 @@ Options:
   -b=, --beta=   float  2.0  shrink target
 
 ==> test/TwoNondefaultedSeq.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 test/TwoNondefaultedSeq.nim(9, 11) template/generic instantiation of `dispatch` from here
 cligen.nim(768, 14) template/generic instantiation of `dispatchCf` from here
 cligen.nim(755, 14) template/generic instantiation of `dispatchGen` from here
+cligen.nim(243, 16) Warning: cligen only supports one seq param for positional args; using `args`, not `stuff`.  Use `positional` parameter to `dispatch` to override this. [User]
 Usage:
   demo [required&optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.
@@ -840,6 +896,7 @@ Options:
   -s=, --stuff=  strings  REQUIRED  append 1 val to stuff
 
 ==> test/TwoNondefaultedSeqSwap.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [required&optional-params] [ stuff (0 or more strings) ]
 demo entry point with varied, meaningless parameters.
@@ -851,6 +908,7 @@ Options:
   --args=        strings  REQUIRED  append 1 val to args
 
 ==> test/UserAliases.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   UserAliases [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters with an alias system.
@@ -867,6 +925,7 @@ Options:
   -i=, --item=    string  ""     set item
 
 ==> test/UserDispIdCollide.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   demo [optional-params] [args: string...]
 This tests if things work when a wrapped user-proc uses identifiers also used in
@@ -879,6 +938,7 @@ Options:
   -g=, --getopt=   string  "ho"        set getopt
 
 ==> test/Version.out <==
+cligen/clCfgInit.nim(114, 9) Warning: observable stores to ':env.r1' [ObservableStores]
 Usage:
   Version [optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.  A Nim invocation might


### PR DESCRIPTION
## Overview

- Version up 'setup-nim-action'
- Skip test on 'macOS' VM because devel-compiler doesn't exist
- Remove compiler-message from 'test/ref'
- Change test script

## Change test script

The current test script writes '--help' message and compiler message to 'test/out'.
It is difficult to ignore with 'grep'.
So I split 'compile' phase and 'run' command phase.


