### PR TITLE
allow different file descriptors & input / output object sizes

### DIFF
--- a/cligen/mslice.nim
+++ b/cligen/mslice.nim
@@ -111,6 +111,12 @@ proc mrite*(f: File, mses: varargs[MSlice]) {.inline.} =
   ## unlocked write all ``mses`` to file ``f``; Be careful of many fwrite()s.
   for ms in items(mses): f.urite ms
 
+proc read*[T](m: MSlice, ob: var T) =
+  ## Assumes `m` starts at beginning of object `ob`! Reads data in slice
+  ## into object `ob` using `copyMem`.
+  doAssert m.len >= ob.sizeof
+  copyMem(m.mem, ob.addr, ob.sizeof)
+
 proc `==`*(a: string, ms: MSlice): bool {.inline.} =
   a.len == ms.len and cmemcmp(unsafeAddr a[0], ms.mem, a.len.csize) == 0
 proc `==`*(ms: MSlice, b: string): bool {.inline.} = b == ms

--- a/cligen/procpool.nim
+++ b/cligen/procpool.nim
@@ -93,7 +93,8 @@ proc initFilter(work: proc(), aux: int, fd0, fd1: cint): Filter {.inline.} =
 
 proc ctrlC() {.noconv.} = quit 130
 const to0 = Timeval(tv_sec: Time(0), tv_usec: 0.clong)
-proc initProcPool*(work: proc(); frames: Frames; jobs=0; aux=0,
+proc initProcPool*(work: proc(); frames: Frames; jobs=0;
+                   auxIn=0, auxOut=0,
                    toR=to0, toW=to0, raiseCtrlC=false,
                    stdreq=stdin.getFileHandle(),
                    stdrep=stdout.getFileHandle()): ProcPool {.noinit.} =
@@ -101,7 +102,7 @@ proc initProcPool*(work: proc(); frames: Frames; jobs=0; aux=0,
   result.kids.setLen (if jobs == 0: countProcessors() else: jobs)
   FD_ZERO result.fdsetW; FD_ZERO result.fdsetR        # ABI=>No rely on Nim init
   for i in 0 ..< result.len:                          # Create Filter kids
-    result.kids[i] = initFilter(work, aux, fd0=stdreq, fd1=stdrep)
+    result.kids[i] = initFilter(work, auxOut, fd0=stdreq, fd1=stdrep)
     if result.kids[i].pid == -1:                      # -1 => fork failed
       for j in 0 ..< i:                               # for prior launched kids:
         discard result.kids[j].fd1.close              #   close fd to kid


### PR DESCRIPTION
This is just a pretty straightforward extension to assign custom file descriptors to use in the kid ⇔ parent communication. The user currently of course has to make sure those exist and can be used. Ideally we would be able to take care of that for the user and provide a `stdreq` / `stdrep` directly in the `work` procedure. 
That could be done either by handing a `stdreq` and `stdrep` argument to `work` or by defining some template of that name?

In addition I replaced `aux` by separate `auxIn` and `auxOut`. But `auxIn` as far as I can tell is actually not even needed (at least not currently). So possibly `aux` can just remain a lone argument always referring to the size of the object for `framesOb`. 

*edit*: Also added a `read` proc for `MSlice` to read into a `var T` object using `copyMem`. I took used `read` instead of `uRd`, because the u = unlocked meaning for `File` is unrelated here. Oh, and we might want to turn that `doAssert` into an `assert` of course.

Here's some example code that shows how to use separate streams with this now:

```nim
import cligen / [procpool, mslice, osUt], cligen, std / [sequtils, os, streams]

type
  ProcData = object # data we hand to each kid worker process
    id: int
    σs: float
    σb: float
    nmc: int

  ProcResult = object # data that is returned as a result
    id: int
    res: float

proc main(jobs: int) =
  var stdreq: File = open("/dev/tty", fmRead) # open our custom streams using `/dev/tty`
  var stdrep: File = open("/dev/tty", fmWrite)
  flushFile stdreq # not needed?
  var pp = initProcPool(
    (proc() =
       var p: ProcData
       while stdreq.uRd(p): # read `ProcData` sized data from our custom input
         echo "hello from one worker! with line: ", p # can output to `stdout` just fine
         var cnt = 0 # do "work"
         for _ in 0 ..< 1_000_000: cnt += 1
         echo "done ", cnt # more output!
         var pRes = ProcResult(id: p.id, res: cnt.float)
         doAssert stdrep.uWr(pRes) # write back to our custom output stream
         flushFile stdrep # needed?
    ),
    # different input and output sizes
    framesOb, jobs = jobs, auxIn = ProcData.sizeof, auxOut = ProcResult.sizeof,
    # and our custom file descriptors
    stdreq = stdreq.getFileHandle(), stdrep = stdrep.getFileHandle())

  # define some data
  let ds = @[ProcData(id: 0, σs: 0.1, σb: 0.1, nmc: 1000),
             ProcData(id: 1, σs: 0.1, σb: 0.2, nmc: 1000),
             ProcData(id: 2, σs: 0.1, σb: 0.3, nmc: 1000),
             ProcData(id: 3, σs: 0.2, σb: 0.1, nmc: 1000),
             ProcData(id: 4, σs: 0.2, σb: 0.2, nmc: 1000),
             ProcData(id: 5, σs: 0.2, σb: 0.3, nmc: 1000)]
  var results = newSeq[float](ds.len)
  var getRes = proc(s: MSlice) =
    var p: ProcResult
    s.read(p)
    doAssert p.id < results.len, "Parsed bad data"
    results[p.id] = p.res
  pp.evalOb ds, getRes
  echo results # got data back correctly despite stdout usage!

when isMainModule:
  dispatch main
```
