### PR TITLE
`procpool` helpers for flat `seq[T]` types

### DIFF
--- a/cligen/mslice.nim
+++ b/cligen/mslice.nim
@@ -117,6 +117,16 @@ proc toOb*[T](m: MSlice, ob: var T) =
   doAssert m.len >= ob.sizeof
   copyMem ob.addr, m.mem, ob.sizeof
 
+proc toSeq*[T](m: MSlice, s: var seq[T]) =
+  ## Reads data in slice `s` into object `seq[T]` using `copyMem`.
+  ##
+  ## Assumes `m` starts at beginning of seq `s`! `T` must either be a flat
+  ## object type or tuple of flat objects (no indirections allowed).
+  let size = m.len div sizeof(T)
+  s = newSeq[T](size)
+  doAssert m.len >= size
+  copyMem s[0].addr, m.mem, m.len
+
 proc `==`*(a: string, ms: MSlice): bool {.inline.} =
   a.len == ms.len and cmemcmp(unsafeAddr a[0], ms.mem, a.len.csize) == 0
 proc `==`*(ms: MSlice, b: string): bool {.inline.} = b == ms

--- a/cligen/osUt.nim
+++ b/cligen/osUt.nim
@@ -423,6 +423,15 @@ proc wrLenBuf*(fd: cint, buf: string): int =
               IOVec(iov_base: buf[0].unsafeAddr, iov_len: buf.len.csize_t) ]
   writev(fd, iov[0].unsafeAddr, 2)
 
+proc wrLenSeq*[T](fd: cint, s: seq[T]): int =
+  ## Write `int` length prefixed data of a `seq[T]` atomically (`writev` on Linux),
+  ## where `T` are either flat objects or tuples of flat objects (no indirections
+  ## allowed).
+  let n = s.len * sizeof(T)
+  let iov = [ IOVec(iov_base: n.unsafeAddr   , iov_len: n.sizeof.csize_t),
+              IOVec(iov_base: s[0].unsafeAddr, iov_len: n.csize_t) ]
+  writev(fd, iov[0].unsafeAddr, 2)
+
 proc lgBold*(f: File, s: string) = f.write "\e[1m", s, "\e[22m"
   ## Log to a `File`, `f` with ANSI SGR bold.
 


### PR DESCRIPTION
This adds two helpers to more easily use `seq[T]` types together with `procpool`.

1. `wrLenSeq` similar to `wrLenBuf`. Writes the `seq[T]` (as long as `T` is flat, use at your own risk) with an integer length prefix using `writev` to a given file descriptor.
2. `toSeq` for `MSlice`. Copies over the data in the given slice to a sequence of `seq[T]` (again, flat `T`). 

Combined they can be used to easily write data from a kid worker back to the parent and fill a resulting sequence.

Until we have an example using this in the repository, here's a snippet of the main parts of my own code for which I just wrote this (it's a MC code where I parallelize over multiple processes to draw more toys).

```nim
type
  ProcData = object
    id: int
    nmc: int

proc computeParallelLimits(ctx: Context, limitKind: LimitKind, nmc: int): seq[(float, int)] =
  var pp = initProcPool(
    (proc(r, w: cint) =
       let i = open(r)
       var p: ProcData
       while i.uRd(p):
         echo "Starting work for ", p
         var rnd = wrap(initMersenneTwister(p.id.uint32))
         var results = newSeq[(float, int)]()
         for i in 0 ..< p.nmc:
           echo "MC index ", i
           ctx.mcIdx = i
           let cands = ctx.drawCandidates(rnd)
           let limit = ctx.computeLimit(rnd, cands, limitKind)
           let cInSens = candsInSens(ctx, cands)
           results.add (limit, cInSens)
         echo "Bytes: ", w.wrLenSeq results),
    framesLenPfx, # use `framesLenPfx` as `wrLenSeq` writes with an int length prefix of the data
    jobs = countProcessors()
  )

  var work = newSeq[ProcData]()
  for i in 0 ..< countProcessors():
    work.add ProcData(id: i, nmc: nmc)

  var limits = newSeq[tuple[limit: float, cInSens: int]]()
  var getRes = proc(s: MSlice) =
    var res: seq[tuple[limit: float, cInSens: int]]
    # use `toSeq` to copy over the slice data back into `res`
    s.toSeq(res)
    limits.add res
  pp.evalOb work, getRes
  result = limits
```

The code as it is of course doesn't compile, but it should get the idea across as a reference for now. 