### PR TITLE
replace shallowCopy with move

### DIFF
--- a/cligen/sysUt.nim
+++ b/cligen/sysUt.nim
@@ -13,7 +13,8 @@ proc findUO*(s: string, c: char): int {.noSideEffect.} =
 proc delete*(x: var string, i: Natural) {.noSideEffect.} =
   ## Just like ``delete(var seq[T], i)`` but for ``string``.
   let xl = x.len
-  for j in i.int .. xl-2: shallowCopy(x[j], x[j+1])
+  for j in i.int .. xl-2:
+    x[j] = move x[j+1]
   setLen(x, xl-1)
 
 iterator maybePar*(parallel: bool, a, b: int): int =


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/pull/20070

Imo, `shallowCopy` only works for string/seq and is about to be removed for ARC/ORC. Inn this case, `move` is better.