### PR TITLE
explicit convert bool types to int types for quoted variables

### DIFF
--- a/cligen.nim
+++ b/cligen.nim
@@ -543,7 +543,7 @@ macro dispatchGen*(pro: typed{nkSym}, cmdName: string="", doc: string="",
         let hlp = helps.getOrDefault(pNm)[1]
         let isReq = if i in mandatory: true else: false
         result.add(quote do:
-         `apId`.parNm = `parNm`; `apId`.parSh = `sh`; `apId`.parReq = `isReq`
+         `apId`.parNm = `parNm`; `apId`.parSh = `sh`; `apId`.parReq = ord(`isReq`)
          `apId`.parRend = if `hky`.len>0: `hky` else:helpCase(`parNm`,clLongOpt)
          let descr = getDescription(`defVal`, `parNm`, `hlp`)
          if descr != `cf`.hTabSuppress:


### PR DESCRIPTION
Here is the definition of `parReq`, which is an int type
```nim
parReq*: int        ## flag indicating parameter is mandatory
```

Here is the definition of `isReq`, which is a boolean type

```nim
let isReq = if i in mandatory: true else: false
```

It is not safe to rely on the type erasure at the compile time, which might be changed in the future => https://github.com/nim-lang/Nim/pull/21433