### PR TITLE
Improvements to `strUt.tmplParse`

### DIFF
--- a/examples/tmpl.nim
+++ b/examples/tmpl.nim
@@ -1,23 +1,36 @@
+from std/strutils import toUpperAscii
 import cligen/strUt     # Example/test text template/macro expand/interpolation.
 
 proc render(fmt: openArray[char]): string =
-  for (id, arg, call) in tmplParse(fmt):
-    if id == 0..0: result.add fmt[arg]
+  for (lit, id, arg, call) in tmplParse2(fmt):
+    if lit: result.add fmt[arg]
     else:
       case fmt[id].toString
       of "a": result.add "hmm"
       of "bc": result.add "hoo"
-      else: result.add fmt[call]
+      of "uc": (for i in arg: result.add fmt[i].toUpperAscii)
+      of "uc hi": result.add "bar"
+      of "(": result.add "lparen"
+      of "}": result.add "rbrace"
+      of "": result.add "nil"
+      else:
+        result.add '?'
+        result.add fmt[call]
+        result.add '?'
 
 for (n, fmt, expect) in [ # This tests a bunch of cases.  Maybe I missed some?
-  ( 0, "hi ${x} ho$y"  ,"hi ${x} ho$y"  ),( 1, "hi $x ho${y}" ,"hi $x ho${y}"),
+  ( 0, "${x} ho$y"     ,"?${x}? ho?$y?" ),( 1, "$x ho${y}"    ,"?$x? ho?${y}?"),
   ( 2, "$a $bc"        ,"hmm hoo"       ),( 3, "${a} ${bc}"   ,"hmm hoo"),
   ( 4, "hi ${(bc)::}ie","hi hooie"      ),( 5, "hi $bc:ther"  ,"hi hoo:ther"),
   ( 6, "hi ${bc:ther"  ,"hi ${bc:ther"  ),( 7, "hi ${(bc:ther","hi ${(bc:ther"),
   ( 8, "hi ${(bc):ther","hi ${(bc):ther"),( 9, "hi $bc:ther$" ,"hi hoo:ther$"),
-  (10, "hi $bc:ther${" ,"hi hoo:ther${" ),(11, "hi ${} ho"    ,"hi ${} ho"),
-  (12, "hi $bc:ther${}","hi hoo:ther${}"),(13, "hi $bc:ther$$","hi hoo:ther$"),
-  (14, "hi $$ ho"      ,"hi $ ho"       ),(15, "hi ${()}"     ,"hi ${()}")]:
+  (10, "hi $bc:ther${" ,"hi hoo:ther${" ),(11, "hi ${} ho"    ,"hi nil ho"),
+  (12, "hi $bc:ther${}","hi hoo:thernil"),(13, "hi $bc:ther$$","hi hoo:ther$"),
+  (14, "hi $$ ho"      ,"hi $ ho"       ),(15, "hi ${()}"     ,"hi nil"),
+  (16, "${(uc)hi} $bc" ,"HI hoo"        ),(17, "$uc ${uc} $bc","  hoo"),
+  (18, "${uc hi} $bc"  ,"bar hoo"       ),(19, "${{uc}hi} $bc","${{uc}hi} hoo"),
+  (20, "$::uc:hi: $bc" ,"niluc:hi: hoo" ),(21, "${.(.} $(}}{)","lparen rbrace"),
+  (22, "${(} ${a}"     ,"${(} hmm"      ),(23, "${(}) ${a}"   ,"${(}) hmm")]:
   if (let s = render(fmt); s != expect):
     echo n, " rendered: \"", s, "\" != expected: \"", expect, "\""
 
@@ -25,6 +38,6 @@ for (n, fmt, expect) in [ # This tests a bunch of cases.  Maybe I missed some?
 ## with another renderer to do: `${(SELECT)x,y FROM Points *** <tr> <td>$1</td>
 ## <td>$2</td> </tr>}` [ the idea being SELECT splits on "***" then loops over
 ## query output rendering a post-*** tmpl to fill an HTML table].  That this can
-## work is no accident. Call syntax was designed to minimize lexical commitments
+## work is no accident.  Call syntax was designed to minimize lexical commitments
 ## to mingle well with surrounding syntax & to let macros define any sub-syntax
 ## in ARG.  Semantics/interpretation/render was also intentionally deferred.

--- a/util/complgen.nim
+++ b/util/complgen.nim
@@ -31,8 +31,8 @@ _@{main}() {
   _arguments \
   @subFlags}"""
   let ind = repeat(' ', 8)
-  for (id, arg, call) in mainTmpl.tmplParse(meta='@'):
-    if id == 0..0: stdout.write mainTmpl[arg]
+  for (lit, id, arg, call) in mainTmpl.tmplParse2(meta='@'):
+    if lit: stdout.write mainTmpl[arg]
     else:
       case mainTmpl[id]
       of "main": stdout.write main
@@ -49,8 +49,8 @@ _@{main}() {
       else: stdout.write mainTmpl[call]
   for sub in subs:
     stdout.write "\n\n"
-    for (id, arg, call) in tmplParse(subTmpl, meta='@'):
-      if id == 0..0: stdout.write subTmpl[arg]
+    for (lit, id, arg, call) in tmplParse2(subTmpl, meta='@'):
+      if lit: stdout.write subTmpl[arg]
       else:
         case subTmpl[id]
         of "sub": stdout.write sub.name


### PR DESCRIPTION
`tmplParse` is a brilliant: its syntax is so flexible yet can be parsed with a few `memchr` calls and an ident-skipping loop. Unfortunately, current implementation is suboptimal and even buggy. I tried to fix/improve it:

1. `${(id)arg}` syntax did not work _at all_ because `a1` was never assigned in the corresponding branch. If you tried to access `fmt[arg]`, you got a `Defect`. Fixed.
2. `${(}a)b}` was parsed as a call with _id=_`}a`, _arg=garbage_, _call=_`${(}`, followed by text `a)b}`. That behaviour feels weird to me. I think these three options are more sensible:
   1. _id=_`}a`, _arg=_`b`, _call=_`${(}a)b}`. I.e., the first `}` is not treated as a closer for the whole call.
   2. _id=_`(`, _arg=empty_, _call=_`${(}`; followed by text `a)b}`. I.e., the first `}` does close the call, and when the parser fails to find `)` inside braces, it treats the whole braced fragment as an identifier.
   3. No macro calls; text `${(}a)b}`. I.e., when the parser sees this gibberish, it gives up, emits it as plain text, and moves on to the next `$`.

   The first option goes against _`fmt` writers must pick non-colliding braces_ rule. Given that it is enforced everywhere else, I doubt it makes much sense to loosen it here. Furthermore, a simple mistake (missing a `)`) can render the rest of the `fmt` invalid, with all macro calls it might contain.

   Other options have none of the abovementioned flaws. I chose the third since it felt more natural to me; also, this is what current implementation does when there are no more `)` characters in the string (as opposed to the case when there _is_ one but beyond braces). Please tell if you’d like to see option 2 implemented.
3. Another change in semantics: parsing `${(a} $b` was resulting in only text chunks. Now it recognizes the `$b` macro call.
4. `${()}` produced a macro call with an empty _id_, while `${}` was parsed as text. (That’s because `i0 == c1` in line 437 is always false.) Fixed.
5. The iterator does not yield empty text chunks anymore. They are hardly useful for users — and sometimes harmful (e.g., when they are pushed to a `seq[string]`). Not having to check for `arg.len != 0` is more convenient.
6. `tmplParse` is an inline iterator so loop body passed to it gets inserted at every `yield` statement. That causes code bloating. Current implementation has 4 `yield`s; I restructured the code so that there are only 2 of them. (Reducing to 1 is not necessary; I’ll explain in a moment.)

   As a side effect, it slightly changed the way meta char’s self-escaping is handled: previously `$` was emitted on its own, and now it becomes part of the following text piece (if there is one). I actually think that auto-merging (at least some) text chunks is an improvement: it leaves less work for the renderer.
7. Current implementation yields either `(0..0, c1..<c0, 0..0)` or `(i0..<i1, a0..<a1, c0..<c1)`, and renderers are supposed to check for `id.a == 0` to see whether they are given a literal text chunk or a macro call. In the former case it is obvious that `(0..0).a == 0` — the compiler is able to do constant propagation and leave only one branch. However, in the latter it fails to prove that `i0 != 0` in general. Therefore, it emits a runtime check and is unable to eliminate dead code in the other branch (therefore, more code bloating).

   This optimization is performed by the backend compiler. I tried communicating `i0 != 0` via `assert`, but it is dropped in the Nim land and the backend compiler does not even see those assertions. While it is possible to employ `__builtin_unreachable()`/`__assume(cond)` for GCC/MSVC, things get harder for the JS backend. So I went with a different approach.

   I introduced `iterator tmplParse2*` (its name is debatable), which yields 4-element tuples: `(lit, id, arg, call)`. `lit` is a `bool` that is `true` for text chunks and `false` for macro calls. Now inserting the correct branch in the correct `yield` position is trivial for the compiler.

   I was considering making an `enum` but thought it isn’t better at anything. Both changing `bool` into `enum` and adding a new `enum` member are breaking changes (the latter — because `case` statements in user code will become non-exhaustive).

I’ve been writing this with a disassembler in my other hand (GCC & Clang) so tiny replacements, such as `< 0` vs `== -1`, are no accident. (`< 0` compiles down to `test` & `js` or sometimes even `sub` & `js` while `== -1` is unable to offer anything better than `cmp` & `je`.)

In the doc comment, [definition lists][rst-def-lists] are (mis)used to indent list items. I did not manage to find a way of making a definition span multiple lines so I had to keep a line longer than 80 characters.

For some reason, `nim doc`, when generating HTML anchors, ignores proc parameters without an explicit type annotation when they have a default value of a `const`. Probably a bug in the docgen. That affects `tmplParse` and `tmplParse2` because of their `ids=alphaNum` parameter. I put `#tmplParse2.i,openArray[char],char` anchor in the doc (incorrect but currently working). Another option is to explicitly declare `ids` to be `set[char]` — the anchor will be `#tmplParse2.i,openArray[char],char,set[char]`, as expected.

Will be glad to hear your opinion on the proposed changes.

[rst-def-lists]: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#definition-lists