### PR TITLE
Enable most warnings for tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,8 +23,11 @@ NIM := $(or $(nim),nim)
 NIM_BACKEND := $(or $(BE),c)
 
 NIM_FLAGS := \
-	--hints:off --warning:all:off --warning:User:on --colors:off\
-	--parallelBuild:$J $(NIM_EXTRA)
+	--verbosity:2 --warning:Deprecated:off --warning:ProveField:off \
+	--hint:Path:off --hint:Conf:off --hint:Processing:off --hint:CC:off \
+	--hint:Exec:off --hint:Source:off --hint:Link:off --hint:SuccessX:off \
+	--hint:GCStats:off \
+	--colors:off --parallelBuild:$J $(NIM_EXTRA)
 NIM_CACHE := $(HOME)/.cache/nim
 
 TESTS_OUT := $(patsubst %.nim,%.out,$(wildcard test/[A-Z]*.nim))

--- a/test.sh
+++ b/test.sh
@@ -2,17 +2,15 @@
 exec < /dev/null
 export COLUMNS="80" CLIGEN_WIDTH="80" CLIGEN=/dev/null
 rm -rf $HOME/.cache/nim/*
-v="--verbosity:1"
-h="--hint[Processing]=off --hint[CC]=off --hint[Exec]=off --hint[SuccessX]=off"
-: ${w="--warning[ObservableStores]:off --warning[Deprecated]:off --warning[ImplicitDefaultValue]:off"}
-if ${nim:-nim} c $w /dev/null 2>&1 | grep -aq 'unknown warning:'; then
-  w=""
-fi
+v="--verbosity:2"
+h="--hint[Path]:off --hint[Conf]:off --hint[Processing]:off --hint[CC]:off"
+h="$h --hint[Exec]:off --hint[Source]:off --hint[Link]:off --hint[SuccessX]:off"
+h="$h --hint[GCStats]:off"
+: ${w="--warning[Deprecated]:off --warning[ProveField]:off"}
 for n in test/[A-Z]*.nim; do
   o=${n%.nim}.out
   c=$HOME/.cache/nim/cache-${n%.nim}
-  #`cat` here is needed to integrate the [User] warning in the output stream.
-  ${nim:-nim} ${BE:-c} --nimcache:$c $v $h $w "$@" --run $n --help 2>&1|cat>$o&
+  ${nim:-nim} ${BE:-c} --nimcache:$c $v $h $w "$@" --run $n --help > $o 2>&1 &
 done
 wait
 for n in $(grep -lw dispatchMulti test/*nim); do

--- a/test/FancyRepeats.nim
+++ b/test/FancyRepeats.nim
@@ -1,3 +1,5 @@
+{.hint[Performance]: off.}
+
 proc demo(alpha=1, verb=0, junk= @[ "rs", "tu" ], stuff= @[ "ab", "cd" ],
           args: seq[string]): int=
   ## demo entry point with varied, meaningless parameters.  A Nim invocation
@@ -14,7 +16,7 @@ when isMainModule:
 
   proc argParse*(dst: var int, dfl: int; a: var ArgcvtParams): bool =
     if a.parNm == "verb":               # make "verb" a special kind of int
-      inc(dst)                          # that just counts its occurances
+      inc(dst)                          # that just counts its occurrences
     else:
       if parseInt(strip(a.val), dst) == 0:
         a.msg = "Bad value: \"$1\" for option \"$2\"; expecting int\n$3" %
@@ -26,7 +28,7 @@ when isMainModule:
     if a.parNm == "verb":    # This is a parNm-conditional hybrid of bool & int
       result = @[ a.argKeys, "countr", $defVal ]
       if a.parSh.len > 0: a.shortNoVal.incl(a.parSh[0])
-      a.longNoVal.add(a.parNm)
+      a.longNoVal.add(a.parNm)          # Triggers hint[Performance]
     else:
       result = @[ a.argKeys, "int", $defVal ]
 

--- a/test/FancyRepeats2.nim
+++ b/test/FancyRepeats2.nim
@@ -1,3 +1,5 @@
+{.hint[Performance]: off.}
+
 proc demo(alpha=1, verb=0, junk= @[ "rs", "tu" ], stuff= @[ "ab", "cd" ],
           args: seq[string]): int=
   ## demo entry point with varied, meaningless parameters.  A Nim invocation
@@ -14,7 +16,7 @@ when isMainModule:
 
   proc argParse*(dst: var int, dfl: int; a: var ArgcvtParams): bool =
     if a.parNm == "verb":               # make "verb" a special kind of int
-      dst = a.parCount                  # that just counts its occurances
+      dst = a.parCount                  # that just counts its occurrences
     else:
       if parseInt(strip(a.val), dst) == 0:
         a.msg = "Bad value: \"$1\" for option \"$2\"; expecting int\n$3" %
@@ -26,7 +28,7 @@ when isMainModule:
     if a.parNm == "verb":    # This is a parNm-conditional hybrid of bool & int
       result = @[ a.argKeys, "countr", $defVal ]
       if a.parSh.len > 0: a.shortNoVal.incl(a.parSh[0])
-      a.longNoVal.add(a.parNm)
+      a.longNoVal.add(a.parNm)          # Triggers hint[Performance]
     else:
       result = @[ a.argKeys, "int", $defVal ]
 

--- a/test/ListDecl.nim
+++ b/test/ListDecl.nim
@@ -1,10 +1,16 @@
 when not declared(addFloat): import std/formatfloat
 
+{.push.}
+when (NimMajor, NimMinor) >= (1, 7):
+  {.warning[ImplicitDefaultValue]: off.}
+
 proc demo(args: seq[int]; alpha, beta: float = 1; verb=false): int =
   ## demo entry point with varied, meaningless parameters.
   echo "alpha:", alpha, " beta:", beta, " verb:", verb
   for i, arg in args: echo "positional[", i, "]: ", arg
   return 42
+
+{.pop.}
 
 when isMainModule:
   import cligen

--- a/test/nim.cfg
+++ b/test/nim.cfg
@@ -1,1 +1,7 @@
 path = ".."
+warning[GcUnsafe] = off
+hint[GlobalVar] = off
+@if nimHasCastPragmaBlocks: # 1.4+
+  warning[ObservableStores] = off
+  hint[MsgOrigin] = off
+@end


### PR DESCRIPTION
So I did what we discussed in #225. I put `GcUnsafe` and `GlobalVar` in `nim.cfg` since cligen uses global variables; there’s nothing a person who wishes to run tests can do with it. `Deprecated` remained in `GNUMakefile`/`test.sh` so you can easily run without it via `w= ./test.sh`; and so did `ProveField` (arguable; might be better to move it to `nim.cfg` too).

As to a strange cat in the pipeline, I suspect you tried `2>&1 >$o`, and it didn’t work because the order of redirections is important. They are processed from left to right: first, stderr is sent to where stdout is _currently_ connected to; then, stdout is redirected to a file. And we want this to happen vice versa. (I ran `test.sh` without final `&`, and the tests passed.)

`hint[Performance]` is indeed issued at a later stage and cannot be scoped, as you told.