### PR TITLE
fix(macUt): ignore comments in nimble file

### DIFF
--- a/cligen/macUt.nim
+++ b/cligen/macUt.nim
@@ -106,7 +106,7 @@ proc newParam*(id: string, rhs: NimNode): NimNode =
   return newNimNode(nnkExprEqExpr).add(ident(id), rhs)
 
 proc fromNimble*(nimbleContents: string, field: string): string =
-  ## ``const x=staticRead "relPathToNimbleFile"; use fromNimble("version",x)``
+  ## ``const x=staticRead "relPathToNimbleFile"; use fromNimble(x, "version")``
   result = "unparsable nimble " & field
   for line in nimbleContents.split("\n"):
     if line.startsWith(field):
@@ -114,8 +114,7 @@ proc fromNimble*(nimbleContents: string, field: string): string =
       if comment < 0:
         comment = line.len()
       let cols = line.substr(0, comment - 1).split('=')
-      result = cols[1].strip()[1..^2]
-      break
+      return cols[1].strip()[1..^2]
 
 proc versionFromNimble*(nimbleContents: string): string {.deprecated:
      "Deprecated since v0.9.31; use fromNimble(...,\"version\") instead."} =

--- a/cligen/macUt.nim
+++ b/cligen/macUt.nim
@@ -110,7 +110,10 @@ proc fromNimble*(nimbleContents: string, field: string): string =
   result = "unparsable nimble " & field
   for line in nimbleContents.split("\n"):
     if line.startsWith(field):
-      let cols = line.split('=')
+      var comment = line.find('#')
+      if comment < 0:
+        comment = line.len()
+      let cols = line.substr(0, comment - 1).split('=')
       result = cols[1].strip()[1..^2]
       break
 


### PR DESCRIPTION
Hi, thanks for the awesome library!

In order to use [release-please](https://github.com/google-github-actions/release-please-action), I need to add a comment on the `version = ` line in `xxx.nimble`.
Example: https://github.com/pysan3/minorg/blob/main/minorg.nimble

Currently, the `fromNimble` function does not take that into account, and the function returns what is not intended. i.e. `file.fromNimble("version")` -> `2.0.1" # {x-release-please-version`

This PR fixes the problem by cutting the comment before returning, as well as some minor fixes to the function.

Hope this helps ;)