### PR TITLE
Introduce "minStrQuoting" option to only quote string defaults when necessary

### DIFF
--- a/cligen.nim
+++ b/cligen.nim
@@ -46,6 +46,7 @@ type    # Main defns CLI authors need be aware of (besides top-level API calls)
     render*:      proc(s: string): string ## string->string help transformer
     widthEnv*:    string         ## name of environment var for width override
     sigPIPE*:     ClSIGPIPE      ## `dispatch` use allows end-user SIGPIPE ctrl
+    minStrQuoting*: bool         ## Only quote string defaults when necessary
 
   HelpOnly*    = object of CatchableError ## Ok Ctl Flow Only For --help
   VersionOnly* = object of CatchableError ## Ok Ctl Flow Only For --version
@@ -507,6 +508,7 @@ macro dispatchGen*(pro: typed{nkSym}, cmdName: string="", doc: string="",
         `tabId`.add(@[ "--" & `helpSyn`[0], "", "", `helpSyn`[1] ])
       `apId`.shortNoVal = { shortH[0] }               # argHelp(bool) updates
       `apId`.longNoVal = @[ "help", "help-syntax" ]   # argHelp(bool) appends
+      `apId`.minStrQuoting = `cf`.minStrQuoting
       let `setByParseId`: ptr seq[ClParse] = `setByParse`
       let `b0` = ha0("bad" , `cf`); let `b1` = ha1("bad" , `cf`)
       let `g0` = ha0("good", `cf`); let `g1` = ha1("good", `cf`)

--- a/cligen/clCfgInit.nim
+++ b/cligen/clCfgInit.nim
@@ -61,6 +61,8 @@ proc apply(c: var ClCfg, path: string, plain=false) =
           for tok in e.value.split: c.hTabCols.add parseEnum[ClHelpCol](tok)
         of "nohelphelp", "skiphelphelp":
           c.noHelpHelp = e.value.optionNormalize in yes
+        of "minstrquoting":
+          c.minStrQuoting = e.value.optionNormalize in yes
         else:
           stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
             "Expecting: rowseparator columngap leastfinal required columns " &

--- a/cligen/clCfgToml.nim
+++ b/cligen/clCfgToml.nim
@@ -45,6 +45,7 @@ proc apply(c: var ClCfg, cfgFile: string, plain=false) =
           c.hTabCols.setLen 0
           for tok in v2.getElems().mapIt(it.getStr()): c.hTabCols.add parseEnum[ClHelpCol](tok)
         of "nohelphelp", "skiphelphelp": c.noHelpHelp = v2.getBool()
+        of "minstrquoting":              c.minStrQuoting = v2.getBool()
         else:
           stderr.write(&"{cfgFile}: unknown keyword {k2} in the [{k1}] section\n")
     of "syntax":


### PR DESCRIPTION
When this option is enabled, string defaults will not be quoted if they are non empty and do not contain any characters that would require quoting them when using the command line (e.g. when they do not contain spaces, new lines, globs, etc.)