### PR TITLE
Make it possible to use the raw, unwrapped docstring

### DIFF
--- a/cligen/clCfgInit.nim
+++ b/cligen/clCfgInit.nim
@@ -65,6 +65,10 @@ proc apply(c: var ClCfg, path: string, plain=false) =
           c.minStrQuoting = e.value.optionNormalize in yes
         of "truedefault": c.trueDefault = e.value
         of "falsedefault": c.falseDefault = e.value
+        of "nowrapdoc":
+          c.nowrapdoc = e.value.optionNormalize in yes
+        of "nowraptable":
+          c.nowraptable = e.value.optionNormalize in yes
         else:
           stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
             "Expecting: rowseparator columngap leastfinal required columns " &

--- a/cligen/clCfgToml.nim
+++ b/cligen/clCfgToml.nim
@@ -48,6 +48,8 @@ proc apply(c: var ClCfg, cfgFile: string, plain=false) =
         of "minstrquoting":              c.minStrQuoting = v2.getBool()
         of "truedefault" : c.trueDefault  = v2.getStr()
         of "falsedefault": c.falseDefault = v2.getStr()
+        of "nowrapdoc":    c.noWrapDocDefaults = v2.getBool()
+        of "nowraptable":  c.noWrapTableDefaults = v2.getBool()
         else:
           stderr.write(&"{cfgFile}: unknown keyword {k2} in the [{k1}] section\n")
     of "syntax":

--- a/cligen/textUt.nim
+++ b/cligen/textUt.nim
@@ -225,7 +225,7 @@ proc mx[T](x: openArray[T]): T =
 
 proc alignTable*(tab: TextTab, prefixLen=0, colGap=2, minLast=16, rowSep="",
     cols = @[0,1], attrOn = @["",""], attrOff = @["",""], aligns = "",
-    width=ttyWidth, measure=printedLen): string =
+    width=ttyWidth, measure=printedLen, noWrapTable=false): string =
   let colsMx = cols.mx + 1
   let aligns = if aligns.len >= colsMx: aligns else: repeat("L", colsMx)
   result = ""
@@ -256,16 +256,16 @@ proc alignTable*(tab: TextTab, prefixLen=0, colGap=2, minLast=16, rowSep="",
       result &= '\n'
       continue
     let wLast = max(minLast, wTerm - leader)
-    var wrapped = if '\n' in row[last]: row[last].split("\n")
+    var lastColText = if noWrapTable or '\n' in row[last]: row[last].split("\n")
                   else: wrap(row[last], wLast).split("\n")
-    result &= attrOn[last] & (if wrapped.len>0: wrapped[0] else: "")
-    if wrapped.len == 1:
+    result &= attrOn[last] & (if lastColText.len>0: lastColText[0] else: "")
+    if lastColText.len == 1:
       result &= attrOff[last] & "\n" & rowSep
     else:
       result &= '\n'
-      for j in 1 ..< wrapped.len - 1:
-        result &= repeat(" ", leader) & wrapped[j] & "\n"
-      result &= repeat(" ",leader) & wrapped[^1] & attrOff[last] & "\n" & rowSep
+      for j in 1 ..< lastColText.len - 1:
+        result &= repeat(" ", leader) & lastColText[j] & "\n"
+      result &= repeat(" ",leader) & lastColText[^1] & attrOff[last] & "\n" & rowSep
 
 type C = int16      ##Type for edit cost values & totals
 const mxC = C.high


### PR DESCRIPTION
This adds two ways to make cligen show the "raw" docstring, avoiding the automatic wrapping that is usually applied to it before display. The default behavior remains unchanged.

The first way to enable this "raw" behavior is by setting the new `rawDoc` configuration flag in `clCfg`.

The second way is by using the new `rawdoc` template variable in the `usage` template, instead of the existing `doc` variable.