### PR TITLE
Replace `textUt.ttyWidth = width` with a more fine-grained control

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,10 +3,6 @@ RELEASE NOTES
 
 Version: 1.7.8
 --------------
-  - Make `cligen/textUt.ttyWidth` a `var` to enable fully draconian CLauthors
-    to hard-code any terminal wrapWidth (set `clCfg.widthEnv=""` to block any
-    run-time CLuser override).
-
   - Allow CLauthors to set `clCfg.minStrQuoting = true` (& CLusers to override
     with `[layout]minStrQuoting = true|false|etc.`) to only put string default
     values in double quotes if "necessary" (presently containing a hard-coded
@@ -16,6 +12,18 @@ Version: 1.7.8
     `[layout]trueDefault = "yes"`) to decide how `argHelp(bool, ..)` renders a
     `true` default value & the very same for `falseDefault`.  `test/Version.nim`
     has an example of both `minStrQuoting` & `falseDefault`.
+
+  - Add 2 new fields to `ClCfg` to control word wrapping in doc-like and table-
+    like contexts, also adjustable via the two provided config-file systems.
+    0=auto terminal width as before, -1 = never wrap, else some specific wrap
+    column (in an absolute sense, including leading indents).  These also apply
+    to the top-level help & subcommand table for multi-cmds.  To truly block
+    CLusers from adjusting wrap, CLauthor must disable use of `clCfg.widthEnv`,
+    and either not include a config file system or do their own that disallows
+    [layout]wrap(Doc|Table) edit.  So, while CLauthors have "ultimate" control,
+    ease is not a priority since CLusers really know the most about what help
+    output will be used for (eg. piping output to grep, $PAGER, etc.).  Sample
+    code showing fine-grained wrap control is in `test/PassValuesMulti.nim`.
 
 Version: 1.7.7
 --------------

--- a/cligen/clCfgInit.nim
+++ b/cligen/clCfgInit.nim
@@ -63,8 +63,10 @@ proc apply(c: var ClCfg, path: string, plain=false) =
           c.noHelpHelp = e.value.optionNormalize in yes
         of "minstrquoting":
           c.minStrQuoting = e.value.optionNormalize in yes
-        of "truedefault": c.trueDefault = e.value
+        of "truedefault" : c.trueDefault  = e.value
         of "falsedefault": c.falseDefault = e.value
+        of "wrapDoc"     : c.wrapDoc      = e.value.parseInt
+        of "wrapTable"   : c.wrapTable    = e.value.parseInt
         else:
           stderr.write path & ":" & " unexpected setting " & e.key & "\n" &
             "Expecting: rowseparator columngap leastfinal required columns " &

--- a/cligen/clCfgToml.nim
+++ b/cligen/clCfgToml.nim
@@ -48,6 +48,8 @@ proc apply(c: var ClCfg, cfgFile: string, plain=false) =
         of "minstrquoting":              c.minStrQuoting = v2.getBool()
         of "truedefault" : c.trueDefault  = v2.getStr()
         of "falsedefault": c.falseDefault = v2.getStr()
+        of "wrapDoc"     : c.wrapDoc      = v2.getInt()
+        of "wrapTable"   : c.wrapTable    = v2.getInt()
         else:
           stderr.write(&"{cfgFile}: unknown keyword {k2} in the [{k1}] section\n")
     of "syntax":

--- a/test/PassValuesMulti.nim
+++ b/test/PassValuesMulti.nim
@@ -12,7 +12,7 @@ proc show(gamma=1, iota=2.0, verb=false, paths: seq[string]): int =
   return 42
 
 proc punt(zeta=1, eta=2.0, verb=false, names: seq[string]): int =
-  ## Another entry point; here we echoResult
+  ## Another entry point; here we can echoResult
   echo "zeta:", zeta, " eta:", eta, " verb:", verb
   for i, n in names: echo "args[", i, "]: ", n
   return 12345
@@ -44,13 +44,18 @@ Run "$command help" to get *comprehensive* help.$ifVersion"""
 
   clCfg.version = "0.0.1" #or maybe nimbleFile.fromNimble("version")
   clCfg.reqSep = true
+  clCfg.widthEnv = "" # Disable CLIGEN_WIDTH CLuser override via impossible $""
 
   var noVsn = clCfg
+  clCfg.wrapDoc = 32; clCfg.wrapTable = 36
   {.pop.}
   noVsn.version = ""
+  noVsn.hTabMinLast = 1 # 11 < default=16 & code does a max(minLast, target).
+  noVsn.wrapDoc = 11; noVsn.wrapTable = -1
   const demohelp = { "verb": "on=chatty, off=quiet" }.toTable
   dispatchMulti([ "multi", doc = docLine, usage = topLvlUse ],
                 [ demo, usage=hlUse, help = demohelp ],
                 [ show, cmdName="print", usage=hlUse, short = { "gamma": 'z' }],
-                [ punt, echoResult=true, usage=hlUse, cf=noVsn ],
+                [ punt, echoResult=true, usage=hlUse, cf=noVsn, help={"zeta":
+                        "very long help string for zeta to show no-wrapping"} ],
                 [ nel_Ly, cmdName="nel-ly", usage=hlUse, noAutoEcho=true ] )

--- a/test/ref
+++ b/test/ref
@@ -652,16 +652,24 @@ Options:
   -a=, --a2=      strings  {}   append 1 val to a2
 
 ==> test/PassValuesMulti.out <==
-Infer & generate command-line interface/option/argument parser
+Infer & generate command-line
+interface/option/argument parser
 Usage:
   PassValuesMulti {SUBCMD}  [sub-command options & parameters]
 
 SUBCMDs:
-  help    print comprehensive or per-cmd help
-  demo    demo entry point with varied, meaningless parameters.
-  print   show entry point with varied, meaningless parameters.
-  punt    Another entry point; here we echoResult
-  nel-ly  Yet another entry point; here we block autoEcho
+  help    print comprehensive or
+          per-cmd help
+  demo    demo entry point with
+          varied, meaningless
+          parameters.
+  print   show entry point with
+          varied, meaningless
+          parameters.
+  punt    Another entry point; here
+          we can echoResult
+  nel-ly  Yet another entry point;
+          here we block autoEcho
 
 PassValuesMulti {-h|--help} or with no args at all prints this message.
 PassValuesMulti --help-syntax gives general cligen syntax help.
@@ -678,16 +686,21 @@ for top-level/all subcommands. Usage is like:
 where subcommand syntaxes are as follows:
 
   [7mdemo [optional-params] [files: string...][m
-  [1m  demo entry point with varied, meaningless parameters.
+  [1m  demo entry point with
+    varied, meaningless
+    parameters.
   [mOptions:
       --version      bool    false  print version
       -a=, --alpha=  int     1      set alpha
       -b=, --beta=   float   2.0    set beta
-      -v, --verb     bool    false  on=chatty, off=quiet
+      -v, --verb     bool    false  on=chatty,
+                                    off=quiet
       -i=, --item=   string  ""     set item
 
   [7mprint [optional-params] [paths: string...][m
-  [1m  show entry point with varied, meaningless parameters.
+  [1m  show entry point with
+    varied, meaningless
+    parameters.
   [mOptions:
       --version      bool   false  print version
       -z=, --gamma=  int    1      set gamma
@@ -695,14 +708,20 @@ where subcommand syntaxes are as follows:
       -v, --verb     bool   false  set verb
 
   [7mpunt [optional-params] [names: string...][m
-  [1m  Another entry point; here we echoResult
+  [1m  Another
+    entry
+    point;
+    here
+    we can
+    echoResult
   [mOptions:
-      -z=, --zeta=  int    1      set zeta
+      -z=, --zeta=  int    1      very long help string for zeta to show no-wrapping
       -e=, --eta=   float  2.0    set eta
       -v, --verb    bool   false  set verb
 
   [7mnel-ly [optional-params] [names: string...][m
-  [1m  Yet another entry point; here we block autoEcho
+  [1m  Yet another entry point;
+    here we block autoEcho
   [mOptions:
       --version      bool  false  print version
       --hooves=      int   4      set hooves
@@ -976,9 +995,9 @@ Options:
 
 ==> test/TwoNondefaultedSeq.out <==
 test/TwoNondefaultedSeq.nim(9, 11) template/generic instantiation of `dispatch` from here
-cligen.nim(922, 14) template/generic instantiation of `dispatchCf` from here
-cligen.nim(909, 14) template/generic instantiation of `dispatchGen` from here
-cligen.nim(303, 16) Warning: cligen only supports one seq param for positional args; using `args`, not `stuff`.  Use `positional` parameter to `dispatch` to override this. [User]
+cligen.nim(925, 14) template/generic instantiation of `dispatchCf` from here
+cligen.nim(912, 14) template/generic instantiation of `dispatchGen` from here
+cligen.nim(305, 16) Warning: cligen only supports one seq param for positional args; using `args`, not `stuff`.  Use `positional` parameter to `dispatch` to override this. [User]
 Usage:
   demo [REQUIRED,optional-params] [args: string...]
 demo entry point with varied, meaningless parameters.


### PR DESCRIPTION
Replace `textUt.ttyWidth = width` with a more fine-grained control mechanism of `wrapDoc`, `wrapTable`.  Special values of `0` mean the old auto-terminal-width wrapping, `-1` means never wrap at all, and other values mean to wrap at that column (including indent). Update both config file parsers to allow CLusers to tweak settings.

Update `test/PassValuesMulti.nim` with some example code showing 4 different wrap columns in play.  Update reference output in light of both `cligen.nim` edits and new `PassValuesMulti` help output.  Also update RELEASE_NOTES.md with details for CLauthors and revert the description (& implementation) of `var ttyWidth` in `textUt.nim` since it is less general.