### PR TITLE
Add $usehdr template variable

### DIFF
--- a/cligen.nim
+++ b/cligen.nim
@@ -606,9 +606,11 @@ macro dispatchGen*(pro: typed{nkSym}, cmdName: string="", doc: string="",
                 else:
                   (if `cf`.useHdr.len > 0: `cf`.useHdr else: clUseHdr) &
                     (if `usageId`.len > 0: `usageId` else: `cf`.use)
+      let useHdr = if `cf`.useHdr.len > 0: `cf`.useHdr else: clUseHdr
       let argStart = "[" & (if `mandatory`.len>0: `apId`.val4req&"," else: "") &
                      "optional-params]"
       `apId`.help = use % ["doc",     hl("doc", indentDoc),
+                           "usehdr", hl("usehdr", useHdr),
                            "command", hl("cmd", `cName`),
                            "args",  hl("args",argStart & " " & posHelp.mayRend),
                            "options", addPrefix(`prefixId` & "  ",

--- a/cligen.nim
+++ b/cligen.nim
@@ -601,12 +601,10 @@ macro dispatchGen*(pro: typed{nkSym}, cmdName: string="", doc: string="",
                     elif `posNm`.len == 0: ""
                     else: "[" & hl("clOptKeys", `posNm`) & ": " &
                           hl("clValType", `posTy`) & "...]"
-      let use = if `noHdrId`:
-                  if `usageId`.len > 0: `usageId` else: `cf`.use
-                else:
-                  (if `cf`.useHdr.len > 0: `cf`.useHdr else: clUseHdr) &
-                    (if `usageId`.len > 0: `usageId` else: `cf`.use)
       let useHdr = if `cf`.useHdr.len > 0: `cf`.useHdr else: clUseHdr
+      var use = if `usageId`.len > 0: `usageId` else: `cf`.use
+      if not `noHdrId` and "$usehdr" notin use and clUseHdr notin use:
+        use = useHdr & use
       let argStart = "[" & (if `mandatory`.len>0: `apId`.val4req&"," else: "") &
                      "optional-params]"
       `apId`.help = use % ["doc",     hl("doc", indentDoc),

--- a/test/PassValues.nim
+++ b/test/PassValues.nim
@@ -10,7 +10,7 @@ when isMainModule:
 
   const cmdName         = "myCmd"     #These are all tested via --help
   const doc             = "The" & " " & "doc"
-  const usage           = "$command $args\n${doc}Options:\n$options"
+  const usage           = "$usehdr$command $args\n${doc}Options:\n$options"
   const helpA           = "growth " & "constant"
   const paramB1         = "be-" & "ta"
   const paramB2         = "b-" & "eta"


### PR DESCRIPTION
Also avoid adding the usage header at the top of the help message when the usage template string is customized and the $usehdr template variable (or the _default_ "Usage:\n" header) is used in it.

Note that this does not change the default behavior in any way. It only makes it easier to completely customize the help message by simply changing the usage template string without having to also set the `noHdr` flag.